### PR TITLE
Feature/admin login 페이지 99% 작업 완료

### DIFF
--- a/admin/login/index.html
+++ b/admin/login/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="ko-KR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>latte-bnb | 관리자 로그인</title>
+    <script type="module" src="./index.js"></script>
+  </head>
+  <body>
+    <main
+      class="min-w-100 h-screen grid grid-col-[400px] grid-rows-[0.4fr_1fr] gap-4 bg-gradient-to-t from-primary-50 via-primary-400 to-primary-100">
+      <a
+        href="/"
+        id="logo"
+        class="w-fit h-15 text-primary-300 flex items-center justify-start self-end justify-self-center focus:outline-primary-500 focus:outline-offset-10 focus:rounded-xl">
+        <svg
+          class="w-12 h-12"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 256 320"
+          role="img"
+          aria-label="latte bnb 로고">
+          <path
+            fill="white"
+            d="M128 12 C78 12 38 52 38 102 C38 170 93 220 121 248 C125 252 131 252 135 248 C163 220 218 170 218 102 C218 52 178 12 128 12Z" />
+          <path
+            fill="currentColor"
+            d="M127 70 L80 105 C77 108 78 114 82 114 L88 114 L88 150 C88 154 91 157 95 157 L161 157 C165 157 168 154 168 150 L168 114 L175 114 C180 114 181 108 178 106 L160 94 L160 74 C160 71 158 69 155 69 L145 69 C142 69 140 71 140 74 L140 79 L133 73 C130 70 126 70 123 73Z" />
+          <rect x="110" y="108" width="14" height="14" rx="2" fill="white" />
+          <rect x="132" y="108" width="14" height="14" rx="2" fill="white" />
+          <rect x="110" y="130" width="14" height="14" rx="2" fill="white" />
+          <rect x="132" y="130" width="14" height="14" rx="2" fill="white" />
+        </svg>
+        <p class="font-semibold text-2xl text-white">lattebnb</p>
+      </a>
+      <form
+        method="post"
+        id="adminLoginForm"
+        class="min-w-100 w-fit self-start justify-self-center p-10 md:border-shark-50 md:border-2 md:rounded-3xl bg-transparent">
+        <fieldset class="flex flex-col gap-8">
+          <legend class="text-3xl text-white font-semibold text-center mb-10">
+            관리자 로그인
+          </legend>
+          <input
+            type="text"
+            id="adminId"
+            class="border-shark-50 text-white border-1 rounded-md px-4 py-2 focus:outline-primary-500 placeholder:text-shark-100"
+            placeholder="아이디" />
+          <input
+            type="password"
+            id="adminPassword"
+            class="border-shark-50 text-white border-1 rounded-md px-4 py-2 focus:outline-primary-500 placeholder:text-shark-100"
+            placeholder="비밀번호" />
+          <button
+            type="submit"
+            class="text-white border-shark-50 border-1 rounded-md py-2 hover:bg-primary-100/50 hover:text-shark-500 focus:outline-primary-500">
+            로그인
+          </button>
+        </fieldset>
+      </form>
+    </main>
+  </body>
+</html>

--- a/admin/login/index.html
+++ b/admin/login/index.html
@@ -4,35 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>latte-bnb | 관리자 로그인</title>
-    <style>
-      [popover] {
-        transition: all 0.3s ease-in-out;
-        &:popover-open {
-          opacity: 1;
-          transform: translateY(0);
-        }
-      }
-      @starting-style {
-        #warnning:popover-open {
-          opacity: 0;
-          transform: translateY(8px);
-        }
-      }
-
-      [popover]:popover-open.closePopover {
-        opacity: 0;
-        transform: translateY(8px);
-      }
-
-      .blankInputMessage {
-        &::before {
-          content: '빈 칸: (';
-        }
-        &::after {
-          content: ')';
-        }
-      }
-    </style>
     <script type="module" src="./index.js"></script>
   </head>
   <body>
@@ -88,13 +59,6 @@
           </button>
         </fieldset>
       </form>
-      <div
-        id="warnning"
-        popover
-        class="absolute top-4/5 left-1/2 -translate-y-full -translate-x-1/2 rounded-2xl p-4 border-1 border-negative-600 bg-negative-300 text-shark-700 shadow-md">
-        <p class="font-semibold">⚠ 빈 칸을 채워주세요.</p>
-        <pre class="blankInputMessage text-sm"></pre>
-      </div>
     </main>
   </body>
 </html>

--- a/admin/login/index.html
+++ b/admin/login/index.html
@@ -4,6 +4,35 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>latte-bnb | 관리자 로그인</title>
+    <style>
+      [popover] {
+        transition: all 0.3s ease-in-out;
+        &:popover-open {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      @starting-style {
+        #warnning:popover-open {
+          opacity: 0;
+          transform: translateY(8px);
+        }
+      }
+
+      [popover]:popover-open.closePopover {
+        opacity: 0;
+        transform: translateY(8px);
+      }
+
+      .blankInputMessage {
+        &::before {
+          content: '빈 칸: (';
+        }
+        &::after {
+          content: ')';
+        }
+      }
+    </style>
     <script type="module" src="./index.js"></script>
   </head>
   <body>
@@ -43,20 +72,29 @@
           <input
             type="text"
             id="adminId"
+            name="adminId"
             class="border-shark-50 text-white border-1 rounded-md px-4 py-2 focus:outline-primary-500 placeholder:text-shark-100"
             placeholder="아이디" />
           <input
             type="password"
             id="adminPassword"
+            name="adminPassword"
             class="border-shark-50 text-white border-1 rounded-md px-4 py-2 focus:outline-primary-500 placeholder:text-shark-100"
             placeholder="비밀번호" />
           <button
             type="submit"
-            class="text-white border-shark-50 border-1 rounded-md py-2 hover:bg-primary-100/50 hover:text-shark-500 focus:outline-primary-500">
+            class="font-extrabold text-white border-shark-50 border-1 rounded-md py-2 hover:bg-primary-100/50 hover:text-shark-500 focus:outline-primary-500">
             로그인
           </button>
         </fieldset>
       </form>
+      <div
+        id="warnning"
+        popover
+        class="absolute top-4/5 left-1/2 -translate-y-full -translate-x-1/2 rounded-2xl p-4 border-1 border-negative-600 bg-negative-300 text-shark-700 shadow-md">
+        <p class="font-semibold">⚠ 빈 칸을 채워주세요.</p>
+        <pre class="blankInputMessage text-sm"></pre>
+      </div>
     </main>
   </body>
 </html>

--- a/admin/login/index.js
+++ b/admin/login/index.js
@@ -1,0 +1,1 @@
+import '../../src/style.css';

--- a/admin/login/index.js
+++ b/admin/login/index.js
@@ -1,1 +1,46 @@
 import '../../src/style.css';
+
+const adminLoginForm = document.getElementById('adminLoginForm');
+const warnning = document.getElementById('warnning');
+const blankInputMessage = document.querySelector('.blankInputMessage');
+let popoverTimer = null;
+
+warnning.addEventListener('transitionend', (e) => {
+  if (
+    !warnning.classList.contains('closePopover') ||
+    !warnning.matches(':popover-open') ||
+    e.propertyName !== 'opacity'
+  ) {
+    return;
+  }
+  warnning.classList.remove('closePopover');
+  warnning.hidePopover();
+});
+
+adminLoginForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+
+  let message = [];
+  let showMessage = false;
+
+  clearTimeout(popoverTimer);
+
+  if (!e.target.adminId.value.trim()) {
+    message.push('아이디');
+    showMessage = true;
+  }
+  if (!e.target.adminPassword.value.trim()) {
+    message.push('비밀번호');
+    showMessage = true;
+  }
+
+  if (showMessage) {
+    blankInputMessage.textContent = message.join(', ');
+    warnning.showPopover();
+    warnning.classList.remove('closePopover');
+
+    popoverTimer = setTimeout(() => {
+      warnning.classList.add('closePopover');
+    }, 2000);
+  }
+});

--- a/admin/login/index.js
+++ b/admin/login/index.js
@@ -1,21 +1,8 @@
 import '../../src/style.css';
+import toast from '../../src/components/toast.js';
+import { adminLogin } from './login.js';
 
 const adminLoginForm = document.getElementById('adminLoginForm');
-const warnning = document.getElementById('warnning');
-const blankInputMessage = document.querySelector('.blankInputMessage');
-let popoverTimer = null;
-
-warnning.addEventListener('transitionend', (e) => {
-  if (
-    !warnning.classList.contains('closePopover') ||
-    !warnning.matches(':popover-open') ||
-    e.propertyName !== 'opacity'
-  ) {
-    return;
-  }
-  warnning.classList.remove('closePopover');
-  warnning.hidePopover();
-});
 
 adminLoginForm.addEventListener('submit', (e) => {
   e.preventDefault();
@@ -23,24 +10,39 @@ adminLoginForm.addEventListener('submit', (e) => {
   let message = [];
   let showMessage = false;
 
-  clearTimeout(popoverTimer);
-
   if (!e.target.adminId.value.trim()) {
     message.push('아이디');
     showMessage = true;
   }
+
   if (!e.target.adminPassword.value.trim()) {
     message.push('비밀번호');
     showMessage = true;
   }
 
   if (showMessage) {
-    blankInputMessage.textContent = message.join(', ');
-    warnning.showPopover();
-    warnning.classList.remove('closePopover');
-
-    popoverTimer = setTimeout(() => {
-      warnning.classList.add('closePopover');
-    }, 2000);
+    toast.warn(
+      '⚠ 빈 칸을 채워주세요.',
+      `${message.join(', ')}가 비어있습니다.`,
+      2,
+    );
+    return;
   }
+
+  const adminInfo = {
+    username: e.target.adminId.value.trim(),
+    password: e.target.adminPassword.value.trim(),
+  };
+
+  const loginPromise = adminLogin(adminInfo);
+  toast.message('관리자 로그인 중입니다...', '', 999);
+  loginPromise
+    .then((result) => {
+      localStorage.setItem('admin_token', result.accessToken);
+      localStorage.setItem('admin_info', JSON.stringify(result.user));
+      toast.success('로그인', '관리자 로그인에 성공했습니다.', 2);
+    })
+    .catch((error) => {
+      toast.warn('로그인', error.message, 2);
+    });
 });

--- a/admin/login/login.js
+++ b/admin/login/login.js
@@ -1,0 +1,19 @@
+import constants from '../../src/constants';
+
+export async function adminLogin(adminInfo) {
+  const res = await fetch(`${constants.API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(adminInfo),
+  });
+
+  const { message, data } = await res.json();
+
+  if (!res.ok) {
+    throw new Error(message);
+  }
+
+  return { accessToken: data.accessToken, user: data.user };
+}

--- a/src/components/toast.js
+++ b/src/components/toast.js
@@ -9,20 +9,20 @@ function buildDefaultToast() {
   toastNode = document.createElement('div');
   toastNode.id = 'toast';
   toastNode.className =
-    'absolute top-4/5 left-1/2 -translate-y-full -translate-x-1/2 rounded-2xl p-4 border-1 border-negative-600 bg-negative-300 text-shark-700 shadow-md';
-  toastNode.appendChild(buildMessage());
-  toastNode.appendChild(buildDetail());
+    'absolute top-4/5 left-1/2 -translate-y-full -translate-x-1/2 rounded-2xl p-4 border-1 border-neutral-600 bg-neutral-300 text-shark-700 shadow-md';
+  toastNode.appendChild(buildMessageNode());
+  toastNode.appendChild(buildDetailNode());
   return toastNode;
 }
 
-function buildMessage() {
+function buildMessageNode() {
   const messageNode = document.createElement('p');
   messageNode.id = 'toastMessage';
   messageNode.className = 'font-semibold';
   return messageNode;
 }
 
-function buildDetail() {
+function buildDetailNode() {
   const detailNode = document.createElement('p');
   detailNode.id = 'toastDetail';
   detailNode.className = 'text-sm';
@@ -43,7 +43,16 @@ function attachTransitionEndEvent() {
   });
 }
 
-function show(message, details = '', duration = 2) {
+function show(duration) {
+  toastNode.showPopover();
+  toastNode.classList.remove('closeToast');
+
+  toastTimer = setTimeout(() => {
+    toastNode.classList.add('closeToast');
+  }, duration * 1000);
+}
+
+function buildMessage(message, details = '') {
   clearTimeout(toastTimer);
   if (!toastNode) {
     toastNode = document.getElementById('toast') || buildDefaultToast();
@@ -76,13 +85,60 @@ function show(message, details = '', duration = 2) {
       toastDetailNode.hidden = true;
     }
   }
-
-  toastNode.showPopover();
-  toastNode.classList.remove('closeToast');
-
-  toastTimer = setTimeout(() => {
-    toastNode.classList.add('closeToast');
-  }, duration * 1000);
 }
 
-export default { show };
+function message(message, details = '', duration = 2) {
+  buildMessage(message, details);
+  toastNode.classList.remove(
+    'bg-negative-300',
+    'border-negative-600',
+    'text-negative-900',
+    'bg-positive-100',
+    'border-positive-600',
+    'text-positive-900',
+  );
+  toastNode.classList.add(
+    'bg-neutral-100',
+    'border-neutral-600',
+    'text-shark-700',
+  );
+  show(duration);
+}
+
+function success(message, details = '', duration = 2) {
+  buildMessage(message, details);
+  toastNode.classList.remove(
+    'bg-negative-300',
+    'border-negative-600',
+    'text-negative-900',
+    'bg-neutral-100',
+    'border-neutral-600',
+    'text-shark-700',
+  );
+  toastNode.classList.add(
+    'bg-positive-100',
+    'border-positive-600',
+    'text-positive-900',
+  );
+  show(duration);
+}
+
+function warn(message, details = '', duration = 2) {
+  buildMessage(message, details);
+  toastNode.classList.remove(
+    'bg-positive-100',
+    'border-positive-600',
+    'text-positive-900',
+    'bg-neutral-100',
+    'border-neutral-600',
+    'text-shark-700',
+  );
+  toastNode.classList.add(
+    'bg-negative-300',
+    'border-negative-600',
+    'text-negative-900',
+  );
+  show(duration);
+}
+
+export default { message, warn, success };

--- a/src/components/toast.js
+++ b/src/components/toast.js
@@ -1,0 +1,88 @@
+import '../styles/toast.css';
+
+let toastNode = null;
+let toastMessageNode = null;
+let toastDetailNode = null;
+let toastTimer = null;
+
+function buildDefaultToast() {
+  toastNode = document.createElement('div');
+  toastNode.id = 'toast';
+  toastNode.className =
+    'absolute top-4/5 left-1/2 -translate-y-full -translate-x-1/2 rounded-2xl p-4 border-1 border-negative-600 bg-negative-300 text-shark-700 shadow-md';
+  toastNode.appendChild(buildMessage());
+  toastNode.appendChild(buildDetail());
+  return toastNode;
+}
+
+function buildMessage() {
+  const messageNode = document.createElement('p');
+  messageNode.id = 'toastMessage';
+  messageNode.className = 'font-semibold';
+  return messageNode;
+}
+
+function buildDetail() {
+  const detailNode = document.createElement('p');
+  detailNode.id = 'toastDetail';
+  detailNode.className = 'text-sm';
+  return detailNode;
+}
+
+function attachTransitionEndEvent() {
+  toastNode.addEventListener('transitionend', (e) => {
+    if (
+      !toastNode.classList.contains('closeToast') ||
+      !toastNode.matches(':popover-open') ||
+      e.propertyName !== 'opacity'
+    ) {
+      return;
+    }
+    toastNode.classList.remove('closeToast');
+    toastNode.hidePopover();
+  });
+}
+
+function show(message, details = '', duration = 2) {
+  clearTimeout(toastTimer);
+  if (!toastNode) {
+    toastNode = document.getElementById('toast') || buildDefaultToast();
+    toastNode.popover = 'manual';
+    attachTransitionEndEvent();
+    if (!toastNode.isConnected) {
+      document.body.appendChild(toastNode);
+    }
+  }
+
+  toastMessageNode = document.querySelector('#toastMessage');
+  if (toastMessageNode === null) {
+    toastMessageNode = buildMessage();
+    toastNode.appendChild(toastMessageNode);
+  }
+
+  toastDetailNode = document.querySelector('#toastDetail');
+  if (toastDetailNode === null && details) {
+    toastDetailNode = buildDetail();
+    toastNode.appendChild(toastDetailNode);
+  }
+
+  toastMessageNode.textContent = message;
+  if (toastDetailNode) {
+    if (details) {
+      toastDetailNode.textContent = details;
+      toastDetailNode.hidden = false;
+    } else {
+      toastDetailNode.textContent = '';
+      toastDetailNode.hidden = true;
+    }
+  }
+
+  toastNode.showPopover();
+  toastNode.classList.remove('closeToast');
+
+  toastTimer = setTimeout(() => {
+    toastNode.classList.add('closeToast');
+  }, duration * 1000);
+}
+
+export default { show };

--- a/src/components/toast.js
+++ b/src/components/toast.js
@@ -9,7 +9,7 @@ function buildDefaultToast() {
   toastNode = document.createElement('div');
   toastNode.id = 'toast';
   toastNode.className =
-    'absolute top-4/5 left-1/2 -translate-y-full -translate-x-1/2 rounded-2xl p-4 border-1 border-neutral-600 bg-neutral-300 text-shark-700 shadow-md';
+    'absolute top-4/5 left-1/2 -translate-y-full -translate-x-1/2 rounded-2xl p-4 border-1 shadow-md';
   toastNode.appendChild(buildMessageNode());
   toastNode.appendChild(buildDetailNode());
   return toastNode;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,4 @@
+const API_BASE_URL = 'https://api.fullstackfamily.com/api/lattebnb/v1';
+export default {
+  API_BASE_URL,
+};

--- a/src/style.css
+++ b/src/style.css
@@ -74,7 +74,17 @@
   --color-negative-950: #440e0b;
 }
 
-body::-webkit-scrollbar {
-  width: 0;
-  background: transparent;
+@layer base {
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus {
+    -webkit-text-fill-color: theme('colors.shark.700');
+    -webkit-box-shadow: 0 0 0 1000px theme('colors.primary.200') inset;
+    box-shadow: 0 0 0 1000px theme('colors.primary.200') inset;
+    transition: background-color 9999s ease-out 0s;
+  }
+  body::-webkit-scrollbar {
+    width: 0;
+    background: transparent;
+  }
 }

--- a/src/styles/toast.css
+++ b/src/styles/toast.css
@@ -1,0 +1,18 @@
+[popover] {
+  transition: all 0.3s ease-in-out;
+  &:popover-open {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@starting-style {
+  [popover]:popover-open {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+[popover]:popover-open.closeToast {
+  opacity: 0;
+  transform: translateY(8px);
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
         landing: resolve(__dirname, 'index.html'),
         signup: resolve(__dirname, 'signup/index.html'),
         roomsDetail: resolve(__dirname, 'rooms-detail/index.html'),
+        adminLogin: resolve(__dirname, 'admin/login/index.html'),
       },
     },
   },


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

#### feat(admin/login): admin login 페이지 마크업, 스타일 추가
- vite.config.js - rollupOption에 admin login페이지 entry point 추가
- 로고 및 폼 마크업
- 스타일은 기본 유저 페이지와 상반된 느낌이 들도록 inverse한 색감을 적용해봄

#### feat(admin/login): admin login페이지 폼 검증 로직 추가
- ~~popover로 빈 칸이 있으면 채울 것을 사용자에게 알림~~
- ~~popover용 마크업 추가~~
* 위 내용은 이후 toast 모듈 추가와 함께 toast 모듈로 기능 이관됨

chore(constants): api base url 상수 추가

#### feat(toast): 사용자에게 정보 전달을 하기 위한 toast 모듈 제작
- components/ 폴더의 toast.js를 import하여 사용할 수 있다.
- ~~toast.show('내용'); 이 제일 기본적인 사용방법이다.~~
- ~~toast.show('메인내용', '세부설명', 몇 초 보여줄지(초 단위));로 호출해도 된다. 2를 몇 초에 넣으면 2초동안 보여준다.~~
* 위 내용은 이후 toast리팩토링 작업에서 세부적인 기능이 더 추가됨
- toast를 커스텀 하고싶다면 html파일에서 id가 toast인 요소를 만들고 여기에 스타일링을 진행하면 된다.
- 또한 메인내용, 세부내용의 스타일을 커스텀하고 싶다면 각각 id를 toastMessage, toastDetail로 설정하고 스타일링을 진행하면 된다.

#### refactor(toast): message, warn, success 3개의 기본 테마를 추가
- 기존 메세지노드를 빌드해서 보여주는 과정을 하나의 함수에서 처리 -> 빌드와 보여주는 코드를 분리함
- 다양한 테마 제공을 위해 빌드 -> 색변경 -> 보여줌으로 동작하게 변경

#### chore(toast): 기본 토스트 스타일 빌드의 배경색을 neutral-100으로 변경

#### chore(tailwindcss): input의 자동완성 시 배경색이 파랗게 변하는 것을 방지하는 css 속성 추가

#### feat(admin/login): admin login 페이지 99% 완료
- admin/login/ - 관리자 로그인 페이지와 관련된 html, js 파일 존재
- login.js - 관리자 로그인 요청함수를 모듈로 분리
- index.js - 관리자 로그인 페이지의 전체적인 로직 코드가 존재
- index.html - 로그인 폼만 남겨두고 다른 필요없는 요소들은 전부 제거함

## 이슈

resolves #32
