### PR TITLE
Feature/landing 페이지 페이지네이션 및 검색, 정렬 api 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,9 +13,18 @@
         class="self-start scroll-m-20 text-[clamp(1.25rem,4vw,2.25rem)] font-extrabold tracking-tight break-keep py-8 mx-[clamp(1.25rem,4vw,5rem)]">
         특별한 추억을 남길 수 있는 공간을 찾아보세요.
       </h1>
+      <div class="self-end mx-[clamp(1.25rem,4vw,5rem)] my-4">
+        <span>정렬: </span>
+        <select id="sort">
+          <option value="dictAsc" selected>가나다 순</option>
+          <option value="dictDesc">가나다 역순</option>
+          <option value="priceAsc">가격 낮은 순</option>
+          <option value="priceDesc">가격 높은 순</option>
+        </select>
+      </div>
       <ul
         id="roomList"
-        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-5 px-[clamp(20px,4vw,80px)]"></ul>
+        class="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-5 px-[clamp(20px,4vw,80px)]"></ul>
     </main>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,9 +8,9 @@
     <script type="module" src="./src/landing.js"></script>
   </head>
   <body>
-    <main class="min-w-100 pb-20">
+    <main id="content" class="min-w-100 pb-20 flex flex-col items-center">
       <h1
-        class="scroll-m-20 text-[clamp(1.25rem,4vw,2.25rem)] font-extrabold tracking-tight break-keep py-8 mx-[clamp(1.25rem,4vw,5rem)]">
+        class="self-start scroll-m-20 text-[clamp(1.25rem,4vw,2.25rem)] font-extrabold tracking-tight break-keep py-8 mx-[clamp(1.25rem,4vw,5rem)]">
         특별한 추억을 남길 수 있는 공간을 찾아보세요.
       </h1>
       <ul

--- a/src/RoomCard.js
+++ b/src/RoomCard.js
@@ -3,38 +3,29 @@ export class RoomCard {
   #title;
   #location;
   #thumbnailUrl;
-  #rating;
-  #reviewCount;
-  #audultPricePerNight;
-  #period;
-  #hostName;
+  #pricing;
+  #maxGuest;
   #element = null;
   #titleNode = null;
   #thumbnailNode = null;
   #priceNode = null;
-  #periodNode = null;
-  #ratingNode = null;
+  #maxGuestNode = null;
+  #locationNode = null;
 
   constructor({
     id,
     title = '',
     location = '',
-    rating = '',
-    reviewCount = 0,
-    audultPricePerNight = 0,
-    period = '',
-    hostName = '',
-    tumbnailUrl = '',
+    maxGuest = 1,
+    pricing = { adultPrice: 0, childPrice: 0, currency: 'KRW' },
+    thumbnailUrl = '',
   }) {
     this.#id = id;
     this.#title = title;
     this.#location = location;
-    this.#rating = rating;
-    this.#reviewCount = reviewCount;
-    this.#audultPricePerNight = audultPricePerNight;
-    this.#period = period;
-    this.#hostName = hostName;
-    this.#thumbnailUrl = tumbnailUrl;
+    this.#maxGuest = maxGuest;
+    this.#pricing = pricing;
+    this.#thumbnailUrl = thumbnailUrl;
     this.#element = this.#buildElement();
   }
 
@@ -44,16 +35,16 @@ export class RoomCard {
     li.dataset.id = this.#id;
 
     li.innerHTML = `
-    <div class="min-w-[320px] w-full bg-slate-50 text-shark-800 rounded-xl overflow-clip shadow-lg cursor-pointer">
-      <div class="accommodationThumbnail w-full h-46 bg-cover bg-center"></div>
-      <div class="p-4 pt-2 grid grid-cols-2 grid-rows-3 gap-1">
+    <div class="min-w-[320px] w-full h-full bg-slate-50 text-shark-800 rounded-xl overflow-clip shadow-lg cursor-pointer ">
+      <img src='${this.#thumbnailUrl}' alt='대표 이미지' class="accommodationThumbnail w-full h-46 object-cover"/>
+      <div class="p-4 pt-2 grid grid-cols-2 grid-rows-[repeat(3,minmax(56px,1fr))] gap-1">
         <p class="accommodationTitle text-lg col-satrt-1"></p>
         <p class="accommodationPrice text-xl font-semibold col-start-2 justify-self-end">
         </p>
-        <p class="accommodationPeriod text-sm row-start-2 self-end"></p>
-        <p class="accommodationRating text-sm row-start-3"></p>
+        <p class="accommodationMaxGuest text-sm row-start-3 col-start-1 self-start"></p>
+        <p class="accommodationLocation text-sm row-start-3 col-start-1 self-end"></p>
         <div
-          class="text-transparent col-start-2 row-start-3 justify-self-end hover:scale-110 transition-[scale] duration-300">
+          class="text-transparent col-start-2 row-start-3 place-self-end hover:scale-110 transition-[scale] duration-300">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="currentColor"
@@ -73,8 +64,8 @@ export class RoomCard {
     this.#titleNode = li.querySelector('.accommodationTitle');
     this.#thumbnailNode = li.querySelector('.accommodationThumbnail');
     this.#priceNode = li.querySelector('.accommodationPrice');
-    this.#periodNode = li.querySelector('.accommodationPeriod');
-    this.#ratingNode = li.querySelector('.accommodationRating');
+    this.#locationNode = li.querySelector('.accommodationLocation');
+    this.#maxGuestNode = li.querySelector('.accommodationMaxGuest');
 
     this.#syncDOM();
 
@@ -83,10 +74,9 @@ export class RoomCard {
 
   #syncDOM() {
     this.#titleNode.textContent = this.#title;
-    this.#thumbnailNode.style.backgroundImage = `url(${this.#thumbnailUrl})`;
-    this.#priceNode.textContent = `₩ ${this.#audultPricePerNight} / 1박`;
-    this.#periodNode.textContent = this.#period;
-    this.#ratingNode.textContent = `★ ${this.#rating}`;
+    this.#priceNode.textContent = `₩ ${this.#pricing.adultPrice} / 1박`;
+    this.#maxGuestNode.textContent = `최대 ${this.#maxGuest}명`;
+    this.#locationNode.textContent = `${this.#location}`;
   }
 
   getElement() {
@@ -97,21 +87,15 @@ export class RoomCard {
     id = this.#id,
     title = this.#title,
     location = this.#location,
-    rating = this.#rating,
-    reviewCount = this.#reviewCount,
-    audultPricePerNight = this.#audultPricePerNight,
-    period = this.#period,
-    hostName = this.#hostName,
+    maxGuest = this.#maxGuest,
+    pricing = this.#pricing,
     tumbnailUrl = this.#thumbnailUrl,
   } = {}) {
     this.#id = id;
     this.#title = title;
     this.#location = location;
-    this.#rating = rating;
-    this.#reviewCount = reviewCount;
-    this.#audultPricePerNight = audultPricePerNight;
-    this.#period = period;
-    this.#hostName = hostName;
+    this.#maxGuest = maxGuest;
+    this.#pricing = pricing;
     this.#thumbnailUrl = tumbnailUrl;
     this.#syncDOM();
   }

--- a/src/RoomCard.js
+++ b/src/RoomCard.js
@@ -35,31 +35,33 @@ export class RoomCard {
     li.dataset.id = this.#id;
 
     li.innerHTML = `
-    <div class="min-w-[320px] w-full h-full bg-slate-50 text-shark-800 rounded-xl overflow-clip shadow-lg cursor-pointer ">
-      <img src='${this.#thumbnailUrl}' alt='대표 이미지' class="accommodationThumbnail w-full h-46 object-cover"/>
-      <div class="p-4 pt-2 grid grid-cols-2 grid-rows-[repeat(3,minmax(56px,1fr))] gap-1">
-        <p class="accommodationTitle text-lg col-satrt-1"></p>
-        <p class="accommodationPrice text-xl font-semibold col-start-2 justify-self-end">
-        </p>
-        <p class="accommodationMaxGuest text-sm row-start-3 col-start-1 self-start"></p>
-        <p class="accommodationLocation text-sm row-start-3 col-start-1 self-end"></p>
-        <div
-          class="text-transparent col-start-2 row-start-3 place-self-end hover:scale-110 transition-[scale] duration-300">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            stroke-width="1"
-            stroke="black"
-            class="size-6">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
-          </svg>
+    <a href="/accommodations-detail/?id=${this.#id}">
+      <div class="min-w-[320px] w-full h-full bg-slate-50 text-shark-800 rounded-xl overflow-clip shadow-lg cursor-pointer ">
+        <img src='${this.#thumbnailUrl}' alt='대표 이미지' class="accommodationThumbnail w-full h-46 object-cover"/>
+        <div class="p-4 pt-2 grid grid-cols-2 grid-rows-[repeat(3,minmax(56px,1fr))] gap-1">
+          <p class="accommodationTitle text-lg col-satrt-1"></p>
+          <p class="accommodationPrice text-xl font-semibold col-start-2 justify-self-end">
+          </p>
+          <p class="accommodationMaxGuest text-sm row-start-3 col-start-1 self-start"></p>
+          <p class="accommodationLocation text-sm row-start-3 col-start-1 self-end"></p>
+          <div
+            class="text-transparent col-start-2 row-start-3 place-self-end hover:scale-110 transition-[scale] duration-300">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              stroke-width="1"
+              stroke="black"
+              class="size-6">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+            </svg>
+          </div>
         </div>
       </div>
-    </div>`;
+    </a>`;
 
     this.#titleNode = li.querySelector('.accommodationTitle');
     this.#thumbnailNode = li.querySelector('.accommodationThumbnail');

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -19,7 +19,14 @@ export function buildHeader() {
     </svg>
     <p class="font-semibold text-2xl">lattebnb</p>
   </a>
-  <input type="text" id="searchInput" class="lg:ml-auto max-w-xl w-full h-10 lg:h-15 bg-white text-shark-800 px-4 py-2 rounded-3xl lg:rounded-4xl shadow-md placeholder:text-shark-600 placeholder:font-medium placeholder:text-center placeholder:bg-[url(./src/assets/search.svg)] placeholder:bg-no-repeat placeholder:bg-[calc(50%-6rem)_0%]" placeholder="특별한 공간 탐색하기" />
+  <div class="lg:ml-auto max-w-xl w-full relative">
+    <input type="text" id="searchInput" class="w-full h-10 lg:h-15 bg-white text-shark-800 px-4 py-2 rounded-3xl lg:rounded-4xl shadow-md placeholder:text-shark-600 placeholder:font-medium placeholder:text-center placeholder:bg-[url(./src/assets/search.svg)] placeholder:bg-no-repeat placeholder:bg-[calc(50%-6rem)_0%]" placeholder="특별한 공간 탐색하기" />
+    <button id="searchBtn" type="button" class="bg-primary-500 hover:bg-primary-500/85 text-white absolute p-2 right-1 lg:right-2 top-1/2 -translate-y-1/2 rounded-[50%]">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 lg:size-6 pointer-events-none">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+      </svg>
+    </button>
+  </div>
   <div class="hidden lg:flex lg:items-center lg:justify-center lg:w-10 lg:aspect-square lg:bg-negative-500 lg:text-white lg:rounded-[50%] lg:ml-auto lg:mr-4">
     <span>A</span>
   </div>

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -1,0 +1,47 @@
+let prevButton = null;
+let nextButton = null;
+let currentPage = null;
+
+function buildPagination({ page, hasNext, hasPrev }) {
+  const pagination = document.createElement('div');
+  pagination.id = 'pagination';
+  pagination.className =
+    'flex gap-4 flex-nowrap p-2 mt-20 items-center justify-center';
+
+  currentPage = document.createElement('div');
+  currentPage.id = 'currentPage';
+  currentPage.textContent = page;
+
+  prevButton = document.createElement('button');
+  prevButton.type = 'button';
+  prevButton.id = 'prevButton';
+  prevButton.className =
+    'aspect-square p-1 flex items-center justify-center not-disabled:cursor-pointer text-shark-700 hover:not-disabled:text-shark-700/80 disabled:text-shark-300';
+  prevButton.innerHTML = `
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+  </svg>
+  `;
+  if (hasPrev === false) {
+    prevButton.disabled = !hasPrev;
+  }
+
+  nextButton = document.createElement('button');
+  nextButton.type = 'button';
+  nextButton.id = 'nextButton';
+  nextButton.className =
+    'aspect-square p-1 flex items-center justify-center cursor-pointer text-shark-700 hover:text-shark-700/70';
+  nextButton.innerHTML = `
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+  </svg>
+  `;
+  if (hasNext === false) {
+    nextButton.disabled = !hasNext;
+  }
+
+  pagination.append(prevButton, currentPage, nextButton);
+  return pagination;
+}
+
+export default { buildPagination };

--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -1,8 +1,13 @@
 let prevButton = null;
 let nextButton = null;
 let currentPage = null;
+let paginationData = {};
 
 function buildPagination({ page, hasNext, hasPrev }) {
+  paginationData.page = page;
+  paginationData.hasNext = hasNext;
+  paginationData.hasPrev = hasPrev;
+
   const pagination = document.createElement('div');
   pagination.id = 'pagination';
   pagination.className =
@@ -18,7 +23,7 @@ function buildPagination({ page, hasNext, hasPrev }) {
   prevButton.className =
     'aspect-square p-1 flex items-center justify-center not-disabled:cursor-pointer text-shark-700 hover:not-disabled:text-shark-700/80 disabled:text-shark-300';
   prevButton.innerHTML = `
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 pointer-events-none">
     <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
   </svg>
   `;
@@ -30,9 +35,9 @@ function buildPagination({ page, hasNext, hasPrev }) {
   nextButton.type = 'button';
   nextButton.id = 'nextButton';
   nextButton.className =
-    'aspect-square p-1 flex items-center justify-center cursor-pointer text-shark-700 hover:text-shark-700/70';
+    'aspect-square p-1 flex items-center justify-center not-disabled:cursor-pointer text-shark-700 hover:not-disabled:text-shark-700/80 disabled:text-shark-300';
   nextButton.innerHTML = `
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 pointer-events-none">
     <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
   </svg>
   `;
@@ -44,4 +49,21 @@ function buildPagination({ page, hasNext, hasPrev }) {
   return pagination;
 }
 
-export default { buildPagination };
+function setCurrentPage(page) {
+  paginationData.page = page;
+  currentPage.textContent = page;
+}
+
+function setPrevNext({ hasPrev, hasNext }) {
+  paginationData.hasPrev = hasPrev;
+  paginationData.hasNext = hasNext;
+  prevButton.disabled = !hasPrev;
+  nextButton.disabled = !hasNext;
+}
+
+export default {
+  setCurrentPage,
+  setPrevNext,
+  buildPagination,
+  paginationData,
+};

--- a/src/landing.js
+++ b/src/landing.js
@@ -1,6 +1,8 @@
 import { RoomCard } from './RoomCard.js';
 import constants from './constants.js';
+import pagination from './components/pagination.js';
 
+const content = document.getElementById('content');
 const roomList = document.getElementById('roomList');
 let roomData = new Map();
 
@@ -9,13 +11,13 @@ async function fetchRooms() {
     method: 'GET',
   });
 
-  const { message, data } = await res.json();
+  const { message, data, meta } = await res.json();
 
   if (!res.ok) {
     throw new Error(message);
   }
 
-  return data.accommodations;
+  return { data, meta };
 }
 
 function renderRooms() {
@@ -31,6 +33,8 @@ function buildRooms(data) {
 }
 
 const result = await fetchRooms();
-console.log(result);
-buildRooms(result);
+buildRooms(result.data.accommodations);
 renderRooms();
+
+console.log(result.meta);
+content.appendChild(pagination.buildPagination(result.meta.pagination));

--- a/src/landing.js
+++ b/src/landing.js
@@ -2,15 +2,21 @@ import { RoomCard } from './RoomCard.js';
 import constants from './constants.js';
 import pagination from './components/pagination.js';
 
+const searchInput = document.getElementById('searchInput');
+const searchBtn = document.getElementById('searchBtn');
+const sortBox = document.getElementById('sort');
 const content = document.getElementById('content');
 const roomList = document.getElementById('roomList');
 let roomData = new Map();
 let pageLimit = 20;
 
 async function fetchRooms() {
-  const res = await fetch(`${constants.API_BASE_URL}/accommodations`, {
-    method: 'GET',
-  });
+  const res = await fetch(
+    `${constants.API_BASE_URL}/accommodations?pageLimit=${pageLimit}&sort=${sortBox.value}`,
+    {
+      method: 'GET',
+    },
+  );
 
   const { message, data, meta } = await res.json();
 
@@ -23,7 +29,24 @@ async function fetchRooms() {
 
 async function fetchPage() {
   const res = await fetch(
-    `${constants.API_BASE_URL}/accommodations?page=${pagination.paginationData.page}&pageLimit=${pageLimit}`,
+    `${constants.API_BASE_URL}/accommodations?page=${pagination.paginationData.page}&pageLimit=${pageLimit}&sort=${sortBox.value}`,
+    {
+      method: 'GET',
+    },
+  );
+
+  const { message, data, meta } = await res.json();
+
+  if (!res.ok) {
+    throw new Error(message);
+  }
+
+  return { data, meta };
+}
+
+async function fetchSearch(query) {
+  const res = await fetch(
+    `${constants.API_BASE_URL}/accommodations?pageLimit=${pageLimit}&query=${query}&sort=${sortBox.value}`,
     {
       method: 'GET',
     },
@@ -65,6 +88,12 @@ renderRooms();
 
 content.appendChild(pagination.buildPagination(result.meta.pagination));
 
+searchInput.addEventListener('keyup', (e) => {
+  if (e.key === 'Enter') {
+    searchBtn.click();
+  }
+});
+
 document.addEventListener('click', async (e) => {
   if (e.target.id === 'prevButton') {
     pagination.setCurrentPage(pagination.paginationData.page - 1);
@@ -74,5 +103,23 @@ document.addEventListener('click', async (e) => {
   if (e.target.id === 'nextButton') {
     pagination.setCurrentPage(pagination.paginationData.page + 1);
     changePage();
+  }
+
+  if (e.target.id === 'searchBtn') {
+    const result = await fetchSearch(searchInput.value);
+    pagination.setCurrentPage(result.meta.pagination.page);
+    buildRooms(result.data.accommodations);
+    renderRooms();
+    pagination.setPrevNext(result.meta.pagination);
+  }
+});
+
+document.addEventListener('change', async (e) => {
+  if (e.target.id === 'sort') {
+    const result = await fetchRooms();
+    pagination.setCurrentPage(result.meta.pagination.page);
+    buildRooms(result.data.accommodations);
+    renderRooms();
+    pagination.setPrevNext(result.meta.pagination);
   }
 });

--- a/src/landing.js
+++ b/src/landing.js
@@ -5,6 +5,7 @@ import pagination from './components/pagination.js';
 const content = document.getElementById('content');
 const roomList = document.getElementById('roomList');
 let roomData = new Map();
+let pageLimit = 20;
 
 async function fetchRooms() {
   const res = await fetch(`${constants.API_BASE_URL}/accommodations`, {
@@ -20,21 +21,58 @@ async function fetchRooms() {
   return { data, meta };
 }
 
+async function fetchPage() {
+  const res = await fetch(
+    `${constants.API_BASE_URL}/accommodations?page=${pagination.paginationData.page}&pageLimit=${pageLimit}`,
+    {
+      method: 'GET',
+    },
+  );
+
+  const { message, data, meta } = await res.json();
+
+  if (!res.ok) {
+    throw new Error(message);
+  }
+
+  return { data, meta };
+}
+
 function renderRooms() {
+  roomList.replaceChildren();
   for (const value of roomData.values()) {
     roomList.appendChild(value.getElement());
   }
 }
 
 function buildRooms(data) {
+  roomData.clear();
   data.forEach((room) => {
     roomData.set(room.id, new RoomCard(room));
   });
+}
+
+async function changePage() {
+  const result = await fetchPage();
+  buildRooms(result.data.accommodations);
+  renderRooms();
+  pagination.setPrevNext(result.meta.pagination);
 }
 
 const result = await fetchRooms();
 buildRooms(result.data.accommodations);
 renderRooms();
 
-console.log(result.meta);
 content.appendChild(pagination.buildPagination(result.meta.pagination));
+
+document.addEventListener('click', async (e) => {
+  if (e.target.id === 'prevButton') {
+    pagination.setCurrentPage(pagination.paginationData.page - 1);
+    changePage();
+  }
+
+  if (e.target.id === 'nextButton') {
+    pagination.setCurrentPage(pagination.paginationData.page + 1);
+    changePage();
+  }
+});

--- a/src/landing.js
+++ b/src/landing.js
@@ -1,33 +1,36 @@
 import { RoomCard } from './RoomCard.js';
+import constants from './constants.js';
 
 const roomList = document.getElementById('roomList');
+let roomData = new Map();
 
-const mockCnt = 10;
-const mockData = [];
+async function fetchRooms() {
+  const res = await fetch(`${constants.API_BASE_URL}/accommodations`, {
+    method: 'GET',
+  });
 
-function fetchRooms() {
-  for (let i = 0; i < mockCnt; i++) {
-    console.log(i);
-    const room = new RoomCard({
-      id: i,
-      title: `강릉 오션뷰 펜션`,
-      location: '강릉',
-      rating: 4.5,
-      reviewCount: 100,
-      audultPricePerNight: 100000,
-      period: '3월 30일 ~ 4월 4일',
-      hostName: `호스트 이름`,
-      tumbnailUrl: '/src/assets/room_thumbnail.webp',
-    });
-    mockData.push(room);
+  const { message, data } = await res.json();
+
+  if (!res.ok) {
+    throw new Error(message);
   }
+
+  return data.accommodations;
 }
 
 function renderRooms() {
-  mockData.forEach((room) => {
-    roomList.appendChild(room.getElement());
+  for (const value of roomData.values()) {
+    roomList.appendChild(value.getElement());
+  }
+}
+
+function buildRooms(data) {
+  data.forEach((room) => {
+    roomData.set(room.id, new RoomCard(room));
   });
 }
 
-fetchRooms();
+const result = await fetchRooms();
+console.log(result);
+buildRooms(result);
 renderRooms();


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

feat(landing): landing 페이지 api 연동
- api 연동 후 응답데이터로 바로 RoomCard를 만들 수 있도록 RoomCard의 멤버 변수를 수정함
- 숙소 이름이 길어 2줄이 되는경우 레이아웃이 깨지는 문제 발생
 -> 카드의 레이아웃 변경
- 썸네일 이미지를 기존 background-image로 처리하던 부분을 img 태그를 사용하도록 변경

feat(landing): pagination 마크업,스타일 추가

feat(landing): 페이지네이션 ui를 통한 페이지 넘기기 기능 추가
- next, prev를 사용하여 페이지를 이동할 수 있음
- 다음 페이지가 없다면 next 비활성화
- 이전 페이지가 없다면 prev 비활성화

feat(landing): 정렬 선택 박스 마크업 추가

feat(landing): RoomCard 마크업 수정
- a태그로 전체를 감싸 id에 해당하는 상세페이지로 이동하도록 함

feat(landing): 검색 버튼 추가

feat(landing): api 호출 방식 변경 및 검색, 정렬에 대한 로직 추가
- 기본적으로 sort와 pageLimit을 포함하도록 변경
- page를 불러올땐 page도 포함
- 검색할땐 query를 포함
- 검색을 하거나, 정렬방법을 변경했을 경우 현재 페이지는 1로 다시 초기화 함
- 검색 시 엔터를 눌러도 검색버튼의 click 이벤트가 발생하도록 함
- 검색 버튼을 누르면 fetchSearch를 통해 검색된 목록을 가져옴
- 정렬 방식 선택박스의 change 이벤트가 감지되면 기본 가져오기를 수행함.

## 이슈

resolves #56
