### PR TITLE
Feature/admin detail 페이지 추가

### DIFF
--- a/admin/accommodation/index.html
+++ b/admin/accommodation/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="ko-KR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>latte-bnb | 관리자 숙소 상세</title>
+    <script type="module" src="./index.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/admin/accommodation/index.html
+++ b/admin/accommodation/index.html
@@ -6,5 +6,7 @@
     <title>latte-bnb | 관리자 숙소 상세</title>
     <script type="module" src="./index.js"></script>
   </head>
-  <body></body>
+  <body class="bg-linear-to-t from-primary-50 to-primary-200">
+    <main id="content" class="w-full flex justify-center"></main>
+  </body>
 </html>

--- a/admin/accommodation/index.html
+++ b/admin/accommodation/index.html
@@ -7,6 +7,9 @@
     <script type="module" src="./index.js"></script>
   </head>
   <body class="bg-linear-to-t from-primary-50 to-primary-200">
+    <div
+      id="btnContainer"
+      class="fixed flex items-center justify-center min-w-50 p-3 min-h-fit bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-primary-300/50"></div>
     <main id="content" class="w-full flex justify-center"></main>
   </body>
 </html>

--- a/admin/accommodation/index.js
+++ b/admin/accommodation/index.js
@@ -1,9 +1,12 @@
 import '../../src/style.css';
 import accommodationForm from '../../src/components/accommodationForm.js';
 import adminLogo from '../adminLogo.js';
+import toast from '../../src/components/toast.js';
+import { deleteAccommodation } from '../adminLanding.js';
 
 const params = new URLSearchParams(location.search);
 const content = document.getElementById('content');
+const btnContainer = document.getElementById('btnContainer');
 
 document.body.prepend(adminLogo.build());
 
@@ -13,3 +16,30 @@ fetchPromise.then(({ success, message }) => {
     content.append(accommodationForm.buildViewMode());
   }
 });
+
+btnContainer.appendChild(buildDeleteBtn());
+
+document.addEventListener('click', async (e) => {
+  if (e.target.classList.contains('deleteAccommodationBtn')) {
+    try {
+      const result = await deleteAccommodation(params.get('id'));
+      if (result.success) {
+        location.replace('/admin/');
+      }
+    } catch (error) {
+      toast.warn('숙소 삭제', error.message, 3);
+    }
+  }
+});
+
+function buildDeleteBtn() {
+  const btn = document.createElement('button');
+  btn.className =
+    'deleteAccommodationBtn bg-primary-500 text-white hover:bg-primary-500/75 p-1 rounded-xl w-8 h-8';
+  btn.innerHTML = `
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 pointer-events-none">
+    <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+  </svg>
+  `;
+  return btn;
+}

--- a/admin/accommodation/index.js
+++ b/admin/accommodation/index.js
@@ -1,11 +1,15 @@
 import '../../src/style.css';
 import accommodationForm from '../../src/components/accommodationForm.js';
+import adminLogo from '../adminLogo.js';
 
 const params = new URLSearchParams(location.search);
+const content = document.getElementById('content');
+
+document.body.prepend(adminLogo.build());
 
 const fetchPromise = accommodationForm.fetchAccommodation(params.get('id'));
 fetchPromise.then(({ success, message }) => {
   if (success) {
-    document.body.append(accommodationForm.buildViewMode());
+    content.append(accommodationForm.buildViewMode());
   }
 });

--- a/admin/accommodation/index.js
+++ b/admin/accommodation/index.js
@@ -1,0 +1,11 @@
+import '../../src/style.css';
+import accommodationForm from '../../src/components/accommodationForm.js';
+
+const params = new URLSearchParams(location.search);
+
+const fetchPromise = accommodationForm.fetchAccommodation(params.get('id'));
+fetchPromise.then(({ success, message }) => {
+  if (success) {
+    document.body.append(accommodationForm.buildViewMode());
+  }
+});

--- a/admin/index.js
+++ b/admin/index.js
@@ -60,6 +60,8 @@ function render() {
 function build(data) {
   accommodationData.clear();
   data.forEach((accommodation) => {
+    const a = document.createElement('a');
+    a.href = `/admin/accommodation/?id=${accommodation.id}`;
     const li = document.createElement('li');
     li.className =
       'accommodationItem rounded-2xl bg-primary-50 p-4 my-2 shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_12px_30px_rgba(0,0,0,0.08)] relative';
@@ -82,7 +84,8 @@ function build(data) {
       '어른: ' + accommodation.pricing.adultPrice + '원';
     li.querySelector('.admin-childPrice').textContent =
       '어린이: ' + accommodation.pricing.childPrice + '원';
-    accommodationData.set(accommodation.id, { accommodation, element: li });
+    a.appendChild(li);
+    accommodationData.set(accommodation.id, { accommodation, element: a });
   });
 }
 

--- a/src/components/accommodationForm.js
+++ b/src/components/accommodationForm.js
@@ -30,7 +30,7 @@ function buildViewMode() {
   element = document.createElement('div');
   element.id = 'accommodation';
   element.className =
-    'min-w-100 w-fit max-w-3xl flex flex-col items-center bg-white gap-4 md:rounded-t-2xl pb-10';
+    'min-w-100 w-full max-w-3xl flex flex-col items-center bg-white gap-4 md:rounded-t-2xl pb-10';
   element.innerHTML = `
     <img src="${originData.thumbnailUrl}" alt="숙소 대표 이미지" id="thumbnail" class="w-full md:rounded-t-2xl" />
     <div id="mainInfo" class="px-4 text-center">

--- a/src/components/accommodationForm.js
+++ b/src/components/accommodationForm.js
@@ -29,29 +29,50 @@ async function fetchAccommodation(id) {
 function buildViewMode() {
   element = document.createElement('div');
   element.id = 'accommodation';
+  element.className =
+    'min-w-100 w-fit max-w-3xl flex flex-col items-center bg-white gap-4 md:rounded-t-2xl pb-10';
   element.innerHTML = `
-    <img src="${originData.thumbnailUrl}" alt="숙소 대표 이미지" />
-    <div id="mainInfo">
-      <h1 id="title"></h1>
-      <p id="address"></p>
+    <img src="${originData.thumbnailUrl}" alt="숙소 대표 이미지" id="thumbnail" class="w-full md:rounded-t-2xl" />
+    <div id="mainInfo" class="px-4 text-center">
+      <h1 id="title" class="scroll-m-20 text-shark-700 text-center text-4xl font-extrabold tracking-tight text-balance"></h1>
+      <p id="address" class="leading-7 text-shark-700 [&:not(:first-child)]:mt-6"></p>
       <div id="subInfo">
-        <span id="region"></span>
-        <span id="maxGuest"></span>
+        <span id="region" class="leading-7 text-shark-500 [&:not(:first-child)]:mt-6 text-sm"></span>
+        <span class="leading-7 text-shark-500 [&:not(:first-child)]:mt-6 text-sm">·</span>
+        <span id="maxGuest" class="leading-7 text-shark-500 [&:not(:first-child)]:mt-6 text-sm"></span>
       </div>
     </div>
-    <p id="description"></p>
-    <div id="images">
-      <h2>숙박장소</h2>
+    <p id="description" class="leading-7 text-shark-700 [&:not(:first-child)]:mt-6 mx-4"></p>
+    <div id="images" class="w-full px-4">
+      <h2 class="scroll-m-20 border-b border-b-shark-200 pb-2 text-3xl text-shark-700 font-semibold tracking-tight first:mt-0 mb-2">숙박장소</h2>
     </div>
-    <div id="pricing">
-      <h2>가격정책 (단위: 원)</h2>
-      <p id="adultPrice"></p>
-      <p id="childPrice"></p>
-      <p id="serviceFee"></p>
+    <div id="pricing" class="px-4 w-full">
+      <h2 class="scroll-m-20 border-b border-b-shark-200 pb-2 text-3xl text-shark-700 font-semibold tracking-tight first:mt-0 mb-2">가격정책 (단위: 원)</h2>
+      <div class="grid grid-cols-[max-content_1fr] text-shark-700">
+        <p id="adultPrice" class="grid grid-cols-subgrid col-span-2">
+          <span class="row-start-1 col-start-1 flex justify-between gap-2 mr-1">
+            <span>성</span>
+            <span>인</span>
+          </span>
+        </p>
+        <p id="childPrice" class="grid grid-cols-subgrid col-span-2">
+          <span class="row-start-2 col-start-1 flex justify-between gap-2 mr-1">
+            <span>어</span>
+            <span>린</span>
+            <span>이</span>
+          </span>
+        </p>
+        <p id="serviceFee" class="grid grid-cols-subgrid col-span-2">
+          <span class="row-start-3 col-start-1 flex justify-between gap-2 mr-1">
+            <span>서비스</span>
+            <span>수수료</span>
+          </span>
+        </p>
+      </div>
     </div>
-    <div id="booking">
-      <h2>예약정책</h2>
-      <p id="minNights"></p>
+    <div id="booking" class="px-4 w-full">
+      <h2 class="scroll-m-20 border-b border-b-shark-200 pb-2 text-3xl text-shark-700 font-semibold tracking-tight first:mt-0 mb-2">예약정책</h2>
+      <p id="minNights" class="text-lg text-shark-700 mb-2 mt-4"></p>
     </div>
   `;
 
@@ -75,11 +96,22 @@ function fillData(isEdit = false) {
     html.maxGuest.textContent = `최대 ${originData.maxGuest}명까지 숙박 가능`;
     html.description.textContent = originData.description;
     html.images.appendChild(fillImages());
-    html.adultPrice.textContent = `성인: ₩${Number.parseInt(originData.pricing.adultPrice).toLocaleString()}`;
-    html.childPrice.textContent = `어린이: ₩${Number.parseInt(originData.pricing.childPrice).toLocaleString()}`;
-    html.serviceFee.textContent = originData.pricing.serviceFee
-      ? `서비스 수수료: ₩${Number.parseInt(originData.pricing.serviceFee).toLocaleString()}`
-      : '서비스 수수료 없음';
+
+    const adultPrice = document.createElement('span');
+    adultPrice.className = 'row-start-1 col-start-2 font-semibold';
+    adultPrice.textContent = `: ₩${Number.parseInt(originData.pricing.adultPrice).toLocaleString()}`;
+    html.adultPrice.appendChild(adultPrice);
+
+    const childPrice = document.createElement('span');
+    childPrice.className = 'row-start-2 col-start-2 font-semibold';
+    childPrice.textContent = `: ₩${Number.parseInt(originData.pricing.childPrice).toLocaleString()}`;
+    html.childPrice.appendChild(childPrice);
+
+    const serviceFee = document.createElement('span');
+    serviceFee.className = 'row-start-3 col-start-2 font-semibold';
+    serviceFee.textContent = `: ₩${Number.parseInt(originData.pricing.serviceFee).toLocaleString()}`;
+    html.serviceFee.appendChild(serviceFee);
+
     html.minNights.textContent = `최소 ${originData.bookingPolicy.minNights}박부터 예약 가능`;
     html.booking.appendChild(fillBlockedDate());
   }
@@ -89,6 +121,8 @@ function fillImages() {
   if (originData.images.length > 0) {
     const container = document.createElement('div');
     container.id = 'imagesContainer';
+    container.className =
+      'w-full flex flex-nowrap gap-5 overflow-x-auto thin-scroll py-4';
 
     for (let image of originData.images) {
       if (!image.url) {
@@ -96,7 +130,9 @@ function fillImages() {
       }
 
       const div = document.createElement('div');
+
       const img = document.createElement('img');
+      img.className = 'min-w-80 w-full aspect-square object-cover rounded-lg';
       img.src = image.url;
 
       const title = document.createElement('h3');
@@ -112,6 +148,8 @@ function fillImages() {
     return container;
   } else {
     const div = document.createElement('div');
+    div.className =
+      'min-h-70 flex items-center justify-center bg-primary-50/50 border-2 border-primary-50 rounded-lg text-shark-700 text-sm';
     div.textContent = '숙박장소 이미지가 없습니다.';
 
     return div;
@@ -122,21 +160,27 @@ function fillBlockedDate() {
   if (originData.bookingPolicy.blockedDates.length > 0) {
     const container = document.createElement('div');
     container.id = 'blockedDates';
+    container.className = 'thin-scroll max-h-100 overflow-y-scroll';
 
     for (let blockedDate of originData.bookingPolicy.blockedDates) {
       const div = document.createElement('div');
+      div.className =
+        'bg-primary-50/50 border-2 border-primary-50 rounded-lg mr-2 my-4 px-4 py-2';
       const blockedRange = document.createElement('p');
-      blockedRange.className = 'blockedRange';
+      blockedRange.className = 'blockedRange text-shark-700 font-semibold';
       blockedRange.textContent =
         '예약 불가 날짜: ' +
         `${blockedDate.startDate} ~ ${blockedDate.endDate}`;
 
       const blockedReason = document.createElement('p');
-      blockedReason.className = 'blockedReason';
-      blockedReason.textContent =
-        '사유: ' + (blockedDate.reason === 'RESERVATION')
-          ? '예약상태'
-          : '관리자지정';
+      blockedReason.innerHTML = `
+      <span>사유 : </span>`;
+      blockedReason.className = 'blockedReason text-sm text-shark-600';
+      blockedReason.appendChild(
+        document.createTextNode(
+          blockedDate.reason === 'RESERVATION' ? '예약상태' : '관리자지정',
+        ),
+      );
 
       div.append(blockedRange, blockedReason);
       container.appendChild(div);
@@ -145,6 +189,8 @@ function fillBlockedDate() {
     return container;
   } else {
     const div = document.createElement('div');
+    div.className =
+      'min-h-70 flex items-center justify-center bg-primary-50/50 border-2 border-primary-50 rounded-lg text-shark-700 text-sm';
     div.textContent = '설정된 예약 불가 날짜가 없습니다.';
 
     return div;

--- a/src/components/accommodationForm.js
+++ b/src/components/accommodationForm.js
@@ -1,0 +1,182 @@
+import constants from '../constants.js';
+
+let originData = null;
+let modifiedData = null;
+let element = null;
+
+async function fetchAccommodation(id) {
+  const res = await fetch(
+    `${constants.API_BASE_URL}/admin/accommodations/${id}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
+      },
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error('HTTP 에러: ' + res.status);
+  }
+
+  const { success, message, data } = await res.json();
+
+  originData = data;
+
+  return { success, message };
+}
+
+function buildViewMode() {
+  element = document.createElement('div');
+  element.id = 'accommodation';
+  element.innerHTML = `
+    <img src="${originData.thumbnailUrl}" alt="숙소 대표 이미지" />
+    <div id="mainInfo">
+      <h1 id="title"></h1>
+      <p id="address"></p>
+      <div id="subInfo">
+        <span id="region"></span>
+        <span id="maxGuest"></span>
+      </div>
+    </div>
+    <p id="description"></p>
+    <div id="images">
+      <h2>숙박장소</h2>
+    </div>
+    <div id="pricing">
+      <h2>가격정책 (단위: 원)</h2>
+      <p id="adultPrice"></p>
+      <p id="childPrice"></p>
+      <p id="serviceFee"></p>
+    </div>
+    <div id="booking">
+      <h2>예약정책</h2>
+      <p id="minNights"></p>
+    </div>
+  `;
+
+  fillData();
+
+  return element;
+}
+
+function buildEditMode() {
+  modifiedData = originData;
+}
+
+function fillData(isEdit = false) {
+  const html = getHTMLReference();
+
+  if (isEdit) {
+  } else {
+    html.title.textContent = originData.title;
+    html.address.textContent = originData.location.address;
+    html.region.textContent = originData.location.region;
+    html.maxGuest.textContent = `최대 ${originData.maxGuest}명까지 숙박 가능`;
+    html.description.textContent = originData.description;
+    html.images.appendChild(fillImages());
+    html.adultPrice.textContent = `성인: ₩${Number.parseInt(originData.pricing.adultPrice).toLocaleString()}`;
+    html.childPrice.textContent = `어린이: ₩${Number.parseInt(originData.pricing.childPrice).toLocaleString()}`;
+    html.serviceFee.textContent = originData.pricing.serviceFee
+      ? `서비스 수수료: ₩${Number.parseInt(originData.pricing.serviceFee).toLocaleString()}`
+      : '서비스 수수료 없음';
+    html.minNights.textContent = `최소 ${originData.bookingPolicy.minNights}박부터 예약 가능`;
+    html.booking.appendChild(fillBlockedDate());
+  }
+}
+
+function fillImages() {
+  if (originData.images.length > 0) {
+    const container = document.createElement('div');
+    container.id = 'imagesContainer';
+
+    for (let image of originData.images) {
+      if (!image.url) {
+        continue;
+      }
+
+      const div = document.createElement('div');
+      const img = document.createElement('img');
+      img.src = image.url;
+
+      const title = document.createElement('h3');
+      title.textContent = image.title;
+
+      const description = document.createElement('p');
+      description.textContent = image.description;
+
+      div.append(img, title, description);
+      container.appendChild(div);
+    }
+
+    return container;
+  } else {
+    const div = document.createElement('div');
+    div.textContent = '숙박장소 이미지가 없습니다.';
+
+    return div;
+  }
+}
+
+function fillBlockedDate() {
+  if (originData.bookingPolicy.blockedDates.length > 0) {
+    const container = document.createElement('div');
+    container.id = 'blockedDates';
+
+    for (let blockedDate of originData.bookingPolicy.blockedDates) {
+      const div = document.createElement('div');
+      const blockedRange = document.createElement('p');
+      blockedRange.className = 'blockedRange';
+      blockedRange.textContent =
+        '예약 불가 날짜: ' +
+        `${blockedDate.startDate} ~ ${blockedDate.endDate}`;
+
+      const blockedReason = document.createElement('p');
+      blockedReason.className = 'blockedReason';
+      blockedReason.textContent =
+        '사유: ' + (blockedDate.reason === 'RESERVATION')
+          ? '예약상태'
+          : '관리자지정';
+
+      div.append(blockedRange, blockedReason);
+      container.appendChild(div);
+    }
+
+    return container;
+  } else {
+    const div = document.createElement('div');
+    div.textContent = '설정된 예약 불가 날짜가 없습니다.';
+
+    return div;
+  }
+}
+
+function getHTMLReference() {
+  const title = element.querySelector('#title');
+  const address = element.querySelector('#address');
+  const region = element.querySelector('#region');
+  const maxGuest = element.querySelector('#maxGuest');
+  const description = element.querySelector('#description');
+  const images = element.querySelector('#images');
+  const adultPrice = element.querySelector('#adultPrice');
+  const childPrice = element.querySelector('#childPrice');
+  const serviceFee = element.querySelector('#serviceFee');
+  const minNights = element.querySelector('#minNights');
+  const booking = element.querySelector('#booking');
+
+  return {
+    title,
+    address,
+    region,
+    maxGuest,
+    description,
+    images,
+    adultPrice,
+    childPrice,
+    serviceFee,
+    minNights,
+    booking,
+  };
+}
+
+export default { fetchAccommodation, buildViewMode };

--- a/src/style.css
+++ b/src/style.css
@@ -155,3 +155,18 @@
     @apply w-full h-fit bg-primary-500 rounded-2xl p-1 my-2 hover:bg-primary-500/70;
   }
 }
+
+@layer utilities {
+  .thin-scroll {
+    &::-webkit-scrollbar {
+      block-size: 0.5rem;
+      inline-size: 0.5rem;
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      border-radius: 0.25rem;
+      background: theme('colors.shark.200');
+    }
+  }
+}


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
chore(admin): detail 페이지 추가로 카드별 상세페이지 링크 연결

feat(admin/detail): 상세보기페이지 기본 마크업 추가
- index.html - 파일만 존재.
- index.js - 쿼리파라미터로 전달받은 id의 숙소 상세정보를 불러온 후 폼 모듈에서 view mode로 html 마크업 빌드
- accommodationForm.js - 관리자 수정페이지, 상세보기 페이지에서 공통으로 쓰는 폼 모듈, view mode, edit mode에 따라 다른 마크업을 반환하도록 제작 예정
- 현재는 view mode의 스타일없는 순수한 마크업 + 데이터 바인딩만 구현되어있다.

feat(admin/accommodation): 관리자 상세페이지 마크업 완료

feat(admin/accommodation): 관리자 상세페이지 99% 완성
- 추후 fixed 영역에 수정버튼을 추가 예정

## 이슈

resolves #34
