### PR TITLE
Refactor: api/client.js에 선언된 request를 이용하도록 수정 및 자잘한 리팩토링

### DIFF
--- a/admin/accommodation/index.html
+++ b/admin/accommodation/index.html
@@ -6,7 +6,7 @@
     <title>latte-bnb | 관리자 숙소 상세</title>
     <script type="module" src="./index.js"></script>
   </head>
-  <body class="bg-linear-to-t from-primary-50 to-primary-200">
+  <body class="min-h-[100vh] bg-linear-to-t from-primary-50 to-primary-200">
     <div
       id="btnContainer"
       class="fixed flex items-center justify-center min-w-50 p-3 min-h-fit bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-primary-300/50"></div>

--- a/admin/accommodation/index.js
+++ b/admin/accommodation/index.js
@@ -3,17 +3,32 @@ import accommodationForm from '../../src/components/accommodationForm.js';
 import adminLogo from '../adminLogo.js';
 import toast from '../../src/components/toast.js';
 import { deleteAccommodation } from '../adminLanding.js';
+import { getProfile } from '../../src/api/auth.js';
 
 const params = new URLSearchParams(location.search);
 const content = document.getElementById('content');
 const btnContainer = document.getElementById('btnContainer');
 
 document.body.prepend(adminLogo.build());
+content.classList.replace('flex', 'hidden');
+
+const profilePromise = getProfile();
+
+profilePromise
+  .then(({ data }) => {
+    if (data.user.role !== 'ADMIN') {
+      throw new Error();
+    }
+  })
+  .catch(() => {
+    location.replace('/admin/login/');
+  });
 
 const fetchPromise = accommodationForm.fetchAccommodation(params.get('id'));
-fetchPromise.then(({ success, message }) => {
+fetchPromise.then(({ success }) => {
   if (success) {
     content.append(accommodationForm.buildViewMode());
+    content.classList.replace('hidden', 'flex');
   }
 });
 

--- a/admin/add/addAccommodation.js
+++ b/admin/add/addAccommodation.js
@@ -1,43 +1,21 @@
-import constants from '../../src/constants.js';
+import { imageRequest, request } from '../../src/api/client.js';
 
 export async function uploadImage(file) {
   const formData = new FormData();
   formData.append('file', file);
 
-  const res = await fetch(
-    `${constants.API_BASE_URL}/admin/accommodations/images`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
-      },
-      body: formData,
-    },
-  );
-
-  if (!res.ok) {
-    throw new Error('이미지 업로드 실패');
-  }
-
-  const { data } = await res.json();
+  const { data } = await imageRequest('/admin/accommodations/images', {
+    method: 'POST',
+    body: formData,
+  });
   return data.imageUrl;
 }
 
 export async function addAccommodation(requestData) {
-  const res = await fetch(`${constants.API_BASE_URL}/admin/accommodations`, {
+  const { success, message, data } = await request('/admin/accommodations', {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
-      'Content-Type': 'application/json',
-    },
     body: JSON.stringify(requestData),
   });
-
-  if (!res.ok) {
-    throw new Error('숙소 추가 실패');
-  }
-
-  const { success, message, data } = await res.json();
 
   return { success, message, data };
 }

--- a/admin/add/index.js
+++ b/admin/add/index.js
@@ -8,36 +8,26 @@ import {
   buildRequestFormData,
   uploadImage,
 } from './addAccommodation.js';
-import constants from '../../src/constants.js';
+import { getProfile } from '../../src/api/auth.js';
 
 const content = document.getElementById('content');
 let addForm = document.getElementById('addForm');
 
 content.insertBefore(adminLogo.build(), addForm);
-content.classList.remove('grid');
-content.classList.add('hidden');
+content.classList.replace('grid', 'hidden');
 
-if (localStorage.getItem('admin_token')) {
-  const res = await fetch(`${constants.API_BASE_URL}/me/profile`, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
-    },
-  });
+const profilePromise = getProfile();
 
-  if (!res.ok) {
+profilePromise
+  .then(({ data }) => {
+    if (data.user.role !== 'ADMIN') {
+      throw new Error();
+    }
+    content.classList.replace('hidden', 'grid');
+  })
+  .catch(() => {
     location.replace('/admin/login/');
-  }
-
-  const { success } = await res.json();
-  if (success) {
-    console.log('유효한 토큰입니다.');
-    content.classList.add('grid');
-    content.classList.remove('hidden');
-  }
-} else {
-  location.replace('/admin/login/');
-}
+  });
 
 let uploadThumbnailBtn = null;
 let deleteThumbnailBtn = null;

--- a/admin/adminLanding.js
+++ b/admin/adminLanding.js
@@ -1,4 +1,4 @@
-import constants from '../src/constants.js';
+import { request } from '../src/api/client.js';
 
 export async function fetchAccommodationList({
   page,
@@ -17,41 +17,17 @@ export async function fetchAccommodationList({
     params.set('query', query);
   }
 
-  const res = await fetch(
-    `${constants.API_BASE_URL}/admin/accommodations?${params}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
-      },
-    },
-  );
-
-  if (!res.ok) {
-    throw new Error('HTTP 에러: ' + res.status);
-  }
-
-  const { data, meta } = await res.json();
+  const { data, meta } = await request(`/admin/accommodations?${params}`, {
+    method: 'GET',
+  });
 
   return { data, meta };
 }
 
 export async function deleteAccommodation(id) {
-  const res = await fetch(
-    `${constants.API_BASE_URL}/admin/accommodations/${id}`,
-    {
-      method: 'DELETE',
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
-      },
-    },
-  );
-
-  if (!res.ok) {
-    throw new Error('HTTP 에러: ' + res.status);
-  }
-
-  const { success, message } = await res.json();
+  const { success, message } = await request(`/admin/accommodations/${id}`, {
+    method: 'DELETE',
+  });
 
   return { success, message };
 }

--- a/admin/index.js
+++ b/admin/index.js
@@ -1,9 +1,9 @@
 import '../src/style.css';
-import constants from '../src/constants';
 import adminLogo from './adminLogo';
 import { deleteAccommodation, fetchAccommodationList } from './adminLanding';
 import pagination from '../src/components/pagination';
 import toast from '../src/components/toast';
+import { getProfile } from '../src/api/auth';
 
 let searchInput = null;
 let searchBtn = null;
@@ -13,42 +13,20 @@ const accommodationList = document.getElementById('accommodationList');
 const accommodationData = new Map();
 
 content.prepend(adminLogo.build());
-content.classList.remove('grid');
-content.classList.add('hidden');
+content.classList.replace('grid', 'hidden');
 
-if (localStorage.getItem('admin_token')) {
-  const res = await fetch(`${constants.API_BASE_URL}/me/profile`, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
-    },
-  });
+const profilePromise = getProfile();
 
-  if (!res.ok) {
-    if (localStorage.getItem('admin_token')) {
-      localStorage.removeItem('admin_token');
+profilePromise
+  .then(({ data }) => {
+    if (data.user.role !== 'ADMIN') {
+      throw new Error();
     }
-    if (localStorage.getItem('admin_Info')) {
-      localStorage.removeItem('admin_info');
-    }
+    content.classList.replace('hidden', 'grid');
+  })
+  .catch(() => {
     location.replace('/admin/login/');
-  }
-
-  const { success } = await res.json();
-  if (success) {
-    console.log('유효한 토큰입니다.');
-    content.classList.add('grid');
-    content.classList.remove('hidden');
-  }
-} else {
-  if (localStorage.getItem('admin_token')) {
-    localStorage.removeItem('admin_token');
-  }
-  if (localStorage.getItem('admin_Info')) {
-    localStorage.removeItem('admin_info');
-  }
-  location.replace('/admin/login/');
-}
+  });
 
 function render() {
   accommodationList.replaceChildren();

--- a/admin/login/index.js
+++ b/admin/login/index.js
@@ -40,13 +40,15 @@ adminLoginForm.addEventListener('submit', (e) => {
   const loginPromise = adminLogin(adminInfo);
   toast.message('관리자 로그인 중입니다...', '', 999);
   loginPromise
-    .then((result) => {
-      localStorage.setItem('admin_token', result.accessToken);
-      localStorage.setItem('admin_info', JSON.stringify(result.user));
-      toast.success('로그인', '관리자 로그인에 성공했습니다.', 2);
+    .then(() => {
+      toast.success('관리자 로그인', '관리자 로그인에 성공했습니다.', 2);
       location.replace('/admin/');
     })
     .catch((error) => {
-      toast.warn('로그인', error.message, 2);
+      toast.warn(
+        '관리자 로그인',
+        error.data ? error.data.message : error.message,
+        2,
+      );
     });
 });

--- a/admin/login/login.js
+++ b/admin/login/login.js
@@ -1,19 +1,23 @@
-import constants from '../../src/constants';
+import { getProfile } from '../../src/api/auth.js';
+import { request } from '../../src/api/client.js';
+import { removeToken, setToken } from '../../src/utils/auth.js';
 
 export async function adminLogin(adminInfo) {
-  const res = await fetch(`${constants.API_BASE_URL}/auth/login`, {
+  const { data } = await request('/auth/login', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
     body: JSON.stringify(adminInfo),
   });
 
-  const { message, data } = await res.json();
+  setToken(data.accessToken);
 
-  if (!res.ok) {
-    throw new Error(message);
+  const {
+    data: {
+      user: { role },
+    },
+  } = await getProfile();
+
+  if (role !== 'ADMIN') {
+    removeToken();
+    throw new Error('해당 페이지는 관리자만 로그인 할 수 있습니다.');
   }
-
-  return { accessToken: data.accessToken, user: data.user };
 }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -20,7 +20,10 @@ export async function request(endpoint, options = {}) {
   });
 
   if (!res.ok) {
-    throw new Error(`HTTP 에러: ${res.status}`);
+    const { message } = await res.json();
+    const error = new Error(`HTTP 에러: ${res.status}`);
+    error.data = { message };
+    throw error;
   }
 
   return res.json();
@@ -31,4 +34,24 @@ export async function authRequest(endpoint, options = {}) {
   if (!token) return null;
 
   return request(endpoint, options);
+}
+
+export async function imageRequest(endpoint, options = {}) {
+  const token = getToken();
+  const headers = {
+    ...options.headers,
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const res = await fetch(`${BASE_URL}${endpoint}`, {
+    ...options,
+    headers,
+  });
+
+  if (!res.ok) {
+    throw new Error('이미지 업로드 실패');
+  }
+
+  return res.json();
 }

--- a/src/components/accommodationForm.js
+++ b/src/components/accommodationForm.js
@@ -1,25 +1,14 @@
-import constants from '../constants.js';
+import { request } from '../api/client.js';
 
 let originData = null;
 let modifiedData = null;
 let element = null;
 
 async function fetchAccommodation(id) {
-  const res = await fetch(
-    `${constants.API_BASE_URL}/admin/accommodations/${id}`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('admin_token')}`,
-      },
-    },
+  const { success, message, data } = await request(
+    `/admin/accommodations/${id}`,
+    { method: 'GET' },
   );
-
-  if (!res.ok) {
-    throw new Error('HTTP 에러: ' + res.status);
-  }
-
-  const { success, message, data } = await res.json();
 
   originData = data;
 

--- a/src/components/emptyState.js
+++ b/src/components/emptyState.js
@@ -1,7 +1,7 @@
 export function buildEmptyState(message) {
   const div = document.createElement('div');
   div.className =
-    'w-full min-h-140 col-span-3 flex gap-20 items-center justify-center text-lg font-semibold text-shark-600';
+    'w-full min-h-140 col-start-1 -col-end-1 flex flex-col md:flex-row gap-5 md:gap-20 items-center justify-center text-lg font-semibold text-shark-600';
 
   const text = document.createTextNode(`${message} `);
   const highlight = document.createElement('span');

--- a/src/landing.js
+++ b/src/landing.js
@@ -1,8 +1,8 @@
 import { RoomCard } from './RoomCard.js';
-import constants from './constants.js';
 import pagination from './components/pagination.js';
 import toast from './components/toast.js';
 import { checkWish } from './api/auth.js';
+import { request } from './api/client.js';
 
 let searchInput = null;
 let searchBtn = null;
@@ -27,18 +27,9 @@ async function fetchAccommodations({ page, query } = {}) {
     params.set('query', query);
   }
 
-  const res = await fetch(
-    `${constants.API_BASE_URL}/accommodations?${params}`,
-    {
-      method: 'GET',
-    },
-  );
-
-  if (!res.ok) {
-    throw new Error('HTTP 에러: ' + res.status);
-  }
-
-  const { data, meta } = await res.json();
+  const { data, meta } = await request(`/accommodations?${params}`, {
+    method: 'GET',
+  });
 
   return { data, meta };
 }

--- a/src/main.js
+++ b/src/main.js
@@ -40,15 +40,11 @@ if (document.body.dataset.footer === 'true') {
 }
 
 async function checkAuth() {
-  try {
-    const data = await getProfile();
+  const res = await getProfile();
 
-    if (data) {
-      return { isAuth: true, data };
-    }
-    return { isAuth: false, data: null };
-  } catch (error) {
-    console.log(error.message + '\n프로필 조회 실패');
+  if (res) {
+    return { isAuth: true, data: res.data.user };
+  } else {
     return { isAuth: false, data: null };
   }
 }

--- a/wishlist/index.js
+++ b/wishlist/index.js
@@ -1,34 +1,24 @@
 import { RoomCard } from '../src/RoomCard.js';
-import constants from '../src/constants.js';
 import pagination from '../src/components/pagination.js';
 import { buildEmptyState } from '../src/components/emptyState.js';
-import { getToken, removeToken } from '../src/utils/auth.js';
+import { removeToken } from '../src/utils/auth.js';
+import { checkWish, getProfile } from '../src/api/auth.js';
+import { request } from '../src/api/client.js';
 
 const content = document.getElementById('content');
+const authPromise = getProfile();
 
-const token = getToken();
-if (token) {
-  const res = await fetch(`${constants.API_BASE_URL}/me/profile`, {
-    method: 'GET',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!res.ok) {
+authPromise
+  .then(({ success }) => {
+    if (success) {
+      content.classList.remove('hidden');
+      content.classList.add('flex');
+    }
+  })
+  .catch(() => {
     removeToken();
     location.replace('/login/');
-  }
-
-  const { success } = await res.json();
-  if (success) {
-    console.log('유효한 토큰입니다.');
-    content.classList.remove('hidden');
-    content.classList.add('flex');
-  }
-} else {
-  location.replace('/login/');
-}
+  });
 
 let roomData = new Map();
 let pageLimit = 20;
@@ -37,47 +27,28 @@ const roomList = document.getElementById('roomList');
 
 async function fetchWishlist({ page } = {}) {
   const params = new URLSearchParams({ pageLimit });
+
   if (page) {
     params.set('page', page);
   }
 
-  const res = await fetch(`${constants.API_BASE_URL}/me/wishlist?${params}`, {
+  const { data, meta } = await request(`/me/wishlist?${params}`, {
     method: 'GET',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
   });
-
-  const { message, data, meta } = await res.json();
-
-  if (!res.ok) {
-    throw new Error(message);
-  }
 
   return { data, meta };
 }
 
 async function checkWished() {
-  const accommodationIds = [...roomData.keys()];
-  const res = await fetch(`${constants.API_BASE_URL}/me/wishlist/check`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ accommodationIds: accommodationIds }),
-  });
-
-  const { success, message, data } = await res.json();
-
-  if (!success) {
+  try {
+    const { data } = await checkWish([...roomData.keys()]);
+    for (let id of data.wishlistedAccommodationIds) {
+      roomData.get(id).setWish(true);
+    }
+  } catch (error) {
     console.log('찜 일괄 체크 실패');
-    console.log(message);
+    console.log(error.message);
     return;
-  }
-
-  for (let id of data.wishlistedAccommodationIds) {
-    roomData.get(id).setWish(true);
   }
 }
 
@@ -116,7 +87,9 @@ const result = await fetchWishlist();
 buildRooms(result.data.accommodations);
 renderRooms();
 
-content.appendChild(pagination.buildPagination(result.meta.pagination));
+if (roomData.size !== 0) {
+  content.appendChild(pagination.buildPagination(result.meta.pagination));
+}
 
 document.addEventListener('click', async (e) => {
   if (e.target.classList.contains('wishHeart')) {


### PR DESCRIPTION
## PR 유형

- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드 리팩토링

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

refactor(wishlist): api호출방식 변경 및 페이지네이션 수정
- api/client.js의 request를 이용하는 방식으로 수정, 위시리스트 일괄 체크는 api/auth.js의 checkWish를 이용
- 페이지의 로그인상태 검증 방식을 api/auth.js의 getProfile을 이용하도록 수정함
- 위시리스트의 아이템이 없을 경우, 페이지네이션을 안보이도록 수정함

refactor(checkAuth): checkAuth의 데이터 반환 형식을 바뀐 getProfile에 맞게 수정함

refactor(landing): api/client.js의 request를 이용하도록 수정
- 기존에 모든 곳에서 중복적으로 사용되는 fetch코드를 request로 통합하고, 이를 이용하여 게시글 목록을 불러오도록
 fetch 호출부를 수정함

style(emptyState): 데스크탑 전체화면에서 중앙에 위치하도록 수정
- col-span-3 제거 후 col-start-1, -col-end-1을 추가하여 어떤 grid템플릿이든 전체너비를 가지도록 수정함

refactor(accommodationForm): 기존 fetch 호출부를 api/client.js의 request를 이용하도록 수정

refactor(client.js): 기존 request함수 수정 및 이미지 업로드용 request 작성
- 기존 request의 에러 메세지를 던지는 부분에서 data키에 서버로부터 받은 메세지를 포함하여 전달하도록 수정(기존엔 HTTP 에러: 에러코드 형식이였음)
- imageRequest는 폼데이터를 제출하는 것이므로 Content-Type은 들어가면 안됨. 따라서 새로운 함수로 작성 함

refactor(admin): 관리자 검증 로직 수정
- api/auth.js의 getProfile을 이용하도록 수정하고 role필드가 ADMIN인지 검증하여 관리자인지 체크함

refactor(admin): api/client.js의 request를 이용하도록 수정

refactor(admin/login): 로그인 로직 수정 및 에러메세지 출력 코드 수정
- 기존 관리자 로그인은 일반 유저 로그인과 다를 것이 없었음.
- request를 이용하도록 수정하고, admin_token이라는 별개의 토큰을 이용하는 게 아닌 accessToken으로 동일하게 이용하도록 수정
- getProfile의 role 필드를 추출하여 ADMIN인지 체크 후 ADMIN이 아니면 토큰 삭제 후 에러를 throw함
- request의 예외 처리부분에서 error.data필드에 서버로부터의 메세지를 포함하도록 수정함에따라
 토스트 에러메세지도 error.data필드가 있다면 data.message를 출력하며, 없을경우엔 error.message를 출력하도록 수정함

refactor(admin/accommodation): 마크업 스타일 수정 및 관리자 검증로직 변경
- 기존 html은 컨텐츠의 내용이 없다면 계속해서 그라디언트가 반복되어 줄무늬 배경이 보이는 문제가 있었음
- body의 최소높이를 뷰포트의 높이로 주어 해결함
- 관리자 검증로직을 추가함

refactor(admin/add): 이미지 업로드, 숙소추가 fetch 호출부 변경 및 관리자 검증 로직 수정
- 이미지 업로드는 api/client.js에 작성한 imageRequest를 이용하도록 수정 숙소 추가는 request를 이용하도록 수정
- 관리자 검증로직을 getProfile에서 role필드를 추출하여 ADMIN인지 체크하도록 수정

- ## 이슈

resolves #143
