### PR TITLE
docs: 2026-04-14 코드 리뷰 및 해결 가이드

### DIFF
--- a/docs/review-20260414.md
+++ b/docs/review-20260414.md
@@ -1,0 +1,382 @@
+# 코드 리뷰 (2026-04-14)
+
+> 리뷰 날짜: 2026-04-14
+> 대상: Latte_BnB (에어비앤비 클론 코딩 프로젝트)
+> 이전 리뷰: [review-20260409.md](./review-20260409.md)
+> 해결 가이드: [review-20260414_해결.md](./review-20260414_해결.md)
+
+---
+
+## 0. 먼저 — 정말 잘하고 있어요
+
+이전 리뷰에서 지적했던 **"공통 모듈을 만들어 놓고 왜 안 쓸까?"** 문제가 이번 리팩토링에서 대부분 해결됐어요. 변경된 파일을 읽으면서 감탄한 부분을 먼저 정리할게요.
+
+- **`src/api/client.js`의 `request`/`authRequest`를 거의 모든 페이지에서 사용하고 있어요.** `wishlist/index.js`, `src/landing.js`, `admin/*`, `src/components/accommodationForm.js`, `profile/profile.js`, `reservation-request/*` 모두 직접 `fetch()`를 호출하지 않아요. 엔드포인트와 HTTP 메서드만 남아서 페이지 코드가 훨씬 읽기 쉬워졌어요.
+- **이미지 업로드 전용 `imageRequest`를 분리한 것도 좋은 판단이에요.** JSON용 `request`와 multipart/form-data용 `imageRequest`는 헤더 처리가 다르니까, 이걸 한 함수에 억지로 합치지 않고 분리한 게 정답이에요.
+- **`src/api/reservation.js`가 새로 생겼어요.** `showReservations`, `getReservationDetail`, `removeReservation`, `createReservation`, `getReservationContext` 같은 예약 관련 API 함수가 한 모듈에 모였어요. 예약 관련 기능이 늘어나면 여기만 수정하면 되니까 응집도가 높아졌어요.
+- **`src/api/auth.js`에 `logout`, `withdraw`가 추가됐어요.** 프로필 페이지가 자체 fetch를 하지 않고 이 함수를 호출해요. 인증 관련 API가 한 곳에 모여 있어요.
+- **회원가입/로그인 페이지에 Enter 키 포커스 이동, 모달 성공 알림이 잘 들어갔어요.** 사용자 입장에서 훨씬 자연스러워요.
+
+여기까지가 정말 좋았던 점이에요. 이제부터는 "조금 더 좋아질 수 있는 부분"을 얘기할게요. 이번 리뷰의 핵심 주제는 **결합도(Coupling)** 와 **응집도(Cohesion)** 예요.
+
+> **결합도**란 "한 곳을 고쳤을 때 다른 곳도 같이 고쳐야 하는 정도"예요. 결합도가 높으면 고장 확률이 올라가요.
+> **응집도**란 "한 모듈 안의 코드들이 얼마나 관련된 일을 하는지"예요. 응집도가 높으면 읽고 고치기 쉬워요.
+>
+> **결합도는 낮게, 응집도는 높게.** 이게 목표예요.
+
+---
+
+## 1. 관리자 권한 검증 로직이 3곳에 복사되어 있어요 (중요도: 높음)
+
+**관련 파일:** `admin/index.js:18-29`, `admin/add/index.js:19-30`, `admin/accommodation/index.js:15-25`
+
+세 파일에 **정확히 같은 코드**가 반복돼요.
+
+```js
+// admin/index.js, admin/add/index.js, admin/accommodation/index.js 모두 동일
+const profilePromise = getProfile();
+
+profilePromise
+  .then(({ data }) => {
+    if (data.user.role !== 'ADMIN') {
+      throw new Error();
+    }
+    content.classList.replace('hidden', 'grid');
+  })
+  .catch(() => {
+    location.replace('/admin/login/');
+  });
+```
+
+지금은 잘 작동하지만, 만약 다음과 같은 변경이 생기면 어떻게 될까요?
+
+- 관리자 검증에 실패했을 때 이동할 경로가 `/admin/login/` 에서 `/admin/signin/`으로 바뀐다면?
+- `getProfile()`의 응답 구조가 `data.user.role`에서 `data.role`로 바뀐다면?
+- `hidden → grid` 외에 `hidden → flex`가 필요한 페이지가 생긴다면?
+
+**세 파일을 전부 찾아서 동시에 고쳐야 해요.** 하나라도 빠뜨리면 버그예요. 이게 "결합도가 높다"는 뜻이에요. 관리자 검증이라는 **하나의 관심사**가 **세 파일에 흩어져** 있기 때문이에요.
+
+**해결 방향**은 `src/api/auth.js`에 `ensureAdmin(onSuccess)` 같은 유틸 함수를 하나 만들고, 세 페이지에서 그 함수를 호출하는 거예요. 세부 방법은 해결 가이드 문서의 이슈 1을 참고해주세요.
+
+> **응집도 힌트:** "관리자인지 확인한다"는 일은 본질적으로 인증과 관련돼 있어요. 그러니까 `src/api/auth.js` 또는 `src/utils/auth.js`에 있는 게 자연스러워요. 각 페이지(`admin/index.js` 등)가 그 일을 직접 하는 건 페이지의 본래 책임(숙소 목록 보여주기)에서 벗어나는 일이에요.
+
+---
+
+## 2. 모달 열기/닫기 로직이 페이지마다 조금씩 다르게 중복되어 있어요 (중요도: 높음)
+
+**관련 파일:** `login/index.js:104-105`, `signup/index.js:161-162`, `reservation-request/reservation-request.js:173-183`, `profile/profile.js:82-87`, `reservations-detail/index.js:131-159`
+
+모달을 여닫는 방식이 페이지마다 조금씩 달라요.
+
+```js
+// login/index.js (invisible/visible + opacity 방식)
+modal.modalContainer.classList.remove('invisible', 'opacity-0');
+modal.modalContainer.classList.add('visible', 'opacity-100');
+```
+
+```js
+// reservation-request/reservation-request.js (hidden/flex 방식)
+function openModal(modal) {
+  modal.classList.remove('hidden');
+  modal.classList.add('flex');
+  document.body.classList.add('overflow-hidden');
+}
+```
+
+```js
+// profile/profile.js (active 클래스 토글 방식)
+withdrawModal.classList.add('active');
+```
+
+```js
+// reservations-detail/index.js (심지어 같은 파일 안에 3가지 모달 방식이 공존)
+function openModal() { elements.cancelModal.classList.remove('hidden'); ... }
+function openModalReverse() { elements.cancelModal.classList.remove('flex'); ... }
+function closeModal() { elements.cancelConfirmModal.classList.add('hidden'); ... }
+function closeModalReverse() { ... }
+function errorModal() { ... }
+function errorModalReverse() { ... }
+```
+
+특히 `reservations-detail/index.js`의 `openModalReverse`, `closeModalReverse`, `errorModal`, `errorModalReverse` 같은 이름은 한 달 뒤에 다시 보면 **무엇을 하는지 이름만 봐서는 알 수 없어요**. "Reverse"가 "닫는다"는 뜻인지, "다른 모달을 연다"는 뜻인지 코드를 읽어봐야 알 수 있어요. 이건 "응집도가 낮다"는 신호예요. 한 함수의 이름이 그 함수의 역할을 설명하지 못하는 상황이에요.
+
+**해결 방향**은 `src/components/modal.js` 같은 공통 모듈을 만들고, 모든 페이지가 `openModal(element)`, `closeModal(element)` 두 함수만 호출하게 하는 거예요. HTML에서는 일관된 클래스(예: `hidden`/`flex` 또는 `data-modal-open` 속성)를 사용하도록 통일해요.
+
+> **응집도 힌트:** "모달을 연다/닫는다"는 본질적으로 "UI 컴포넌트를 보이게/숨기게 한다"는 일이에요. 그러니까 **UI 컴포넌트 모듈** 안에 있는 게 자연스러워요. 각 페이지 로직 안에 있으면 페이지 코드가 비즈니스 로직과 UI 로직을 둘 다 짊어지게 돼요.
+
+---
+
+## 3. 같은 삭제 버튼 SVG가 두 파일에 복사되어 있어요 (중요도: 중간)
+
+**관련 파일:** `admin/index.js:70-80`, `admin/accommodation/index.js:50-60`
+
+두 파일에 **똑같은 SVG**를 가진 `buildDeleteBtn()` 함수가 따로 정의돼 있어요.
+
+```js
+// admin/index.js
+function buildDeleteBtn() {
+  const btn = document.createElement('button');
+  btn.className = 'deleteAccommodationBtn absolute bg-primary-500 ...';
+  btn.innerHTML = `<svg ...><path d="m14.74 9-.346 9m-4.788 0..."/></svg>`;
+  return btn;
+}
+```
+
+```js
+// admin/accommodation/index.js
+function buildDeleteBtn() {
+  const btn = document.createElement('button');
+  btn.className = 'deleteAccommodationBtn bg-primary-500 ...'; // className만 아주 약간 다름!
+  btn.innerHTML = `<svg ...><path d="m14.74 9-.346 9m-4.788 0..."/></svg>`;
+  return btn;
+}
+```
+
+SVG 같은 긴 문자열이 두 파일에 복사되면 디자이너가 아이콘을 바꿀 때 한 곳만 고치고 다른 곳을 깜빡할 확률이 커요. 그러면 목록 페이지와 상세 페이지의 휴지통 모양이 달라져요.
+
+**해결 방향**은 `src/components/deleteButton.js` 같은 공통 컴포넌트로 빼는 거예요. 위치/크기 관련 className 차이는 함수 매개변수로 받으면 돼요. 세부 방법은 해결 가이드의 이슈 3을 참고해주세요.
+
+---
+
+## 4. 에러 메시지 문자열을 직접 비교하고 있어요 (중요도: 중간)
+
+**관련 파일:** `profile/profile.js:33`, `reservation-request/reservation-request.js:22`
+
+```js
+// profile/profile.js:33
+if (error.message === 'HTTP 에러: 401') {
+  alert('로그인을 먼저 해주세요');
+  location.href = '/login/';
+}
+```
+
+```js
+// reservation-request/reservation-request.js:22
+if (error.message === 'HTTP 에러: 401') {
+  alert('로그인이 필요합니다.');
+  location.href = '/login/';
+}
+```
+
+이건 `src/api/client.js`가 던지는 에러 메시지 **문자열 그대로**를 비교하고 있어요. `client.js`가 나중에 다음처럼 바뀐다면 어떻게 될까요?
+
+- `throw new Error('HTTP 에러: 401')` → `throw new Error('요청 실패: 401')`
+- 메시지를 한국어에서 영어로 바꾸면? (`'Unauthorized (401)'`)
+
+**그 순간 위 두 파일이 조용히 망가져요.** 에러는 계속 나지만, `if` 조건이 더 이상 `true`가 되지 않아서 로그인 페이지로 리다이렉트되지 않아요. 사용자는 "프로필 정보를 불러오는 중 오류가 발생했습니다" 같은 엉뚱한 알림만 보게 돼요.
+
+이것도 "결합도"의 대표적인 예시예요. `profile.js`와 `reservation-request.js`가 **`client.js`의 내부 구현(에러 메시지 문자열)** 에 붙어 있어요.
+
+**해결 방향**은 `client.js`에서 에러를 던질 때 `status`나 `code` 같은 **구조화된 프로퍼티**를 붙이고, 호출하는 쪽에서는 문자열 대신 그 프로퍼티를 보는 거예요.
+
+```js
+// 이미 client.js에 error.data = { message } 를 붙이는 패턴이 있으니
+// error.status도 같이 붙이면 돼요.
+if (error.status === 401) { ... }
+```
+
+세부 방법은 해결 가이드의 이슈 4를 참고해주세요.
+
+---
+
+## 5. `reservations-detail/index.js`가 `getToken()`을 자체 구현하고 있어요 (중요도: 중간)
+
+**관련 파일:** `reservations-detail/index.js:6-12`
+
+```js
+// reservations-detail/index.js
+const storageKeys = {
+  token: 'accessToken',
+};
+
+function getToken() {
+  return localStorage.getItem(storageKeys.token);
+}
+```
+
+그런데 프로젝트에는 이미 `src/utils/auth.js`에 `getToken`, `setToken`, `removeToken`이 준비돼 있어요. 다른 파일들은 모두 거기서 import해서 쓰고 있어요. 이 파일만 자기만의 구현을 따로 들고 있어요.
+
+만약 토큰 저장소를 `localStorage`에서 `sessionStorage`로 바꾼다면? `src/utils/auth.js`를 고치면 다른 페이지는 다 반영되는데, 이 파일만 `localStorage`를 계속 쓰게 돼요. 로그인해도 예약 상세 페이지만 "로그인이 필요합니다"가 뜨는 상황이 벌어질 수 있어요.
+
+**해결 방향**은 간단해요. 지역 `storageKeys`와 `getToken`을 지우고, `src/utils/auth.js`에서 import하면 끝이에요.
+
+> **응집도 힌트:** "토큰 꺼내기"는 페이지의 책임이 아니라 **인증 유틸의 책임**이에요. 페이지는 그 함수를 호출만 하면 돼요.
+
+---
+
+## 6. `style.css`에서 `@apply`로 만든 관리자 전용 클래스 (중요도: 중간)
+
+**관련 파일:** `src/style.css:141-156`
+
+```css
+.adminInputText,
+.adminInputNumber,
+.adminInputDate {
+  @apply border-shark-50 text-white border-1 h-10 px-4 py-2 rounded-md ...;
+}
+.adminLabel {
+  @apply font-semibold text-white text-lg;
+}
+.adminThumbnailUpload,
+.adminImagesUpload {
+  @apply bg-shark-700/20 w-full max-w-90 rounded-2xl aspect-square hover:bg-shark-700/15;
+}
+.adminThumbnailModify {
+  @apply w-full h-fit bg-primary-500 rounded-2xl p-1 my-2 hover:bg-primary-500/70;
+}
+```
+
+Tailwind CSS를 쓰는 이유는 **"CSS 파일을 건드리지 않고 HTML 마크업만 보면 스타일을 알 수 있게"** 하는 거예요. 그런데 `@apply`로 여러 유틸리티를 하나의 클래스로 묶으면, 그 클래스가 어떤 스타일인지 보려면 다시 CSS 파일을 열어야 해요. Tailwind를 쓰는 의미가 반쯤 사라져요.
+
+또 한 가지 문제는 `admin/add/index.js:52`, `admin/add/index.js:65` 같은 곳에서 JS가 직접 이런 문자열을 다뤄요.
+
+```js
+uploadThumbnailBtn.className = 'adminThumbnailModify';
+// ...
+uploadThumbnailBtn.className = 'adminThumbnailUpload';
+```
+
+JS 안에 `adminThumbnailModify`라는 이름이 있고, CSS 파일에 같은 이름이 있고, HTML에도 같은 이름이 있어야 해요. **셋이 손을 꼭 잡고 있어야 동작해요.** 하나만 오타가 나도 조용히 깨져요.
+
+**해결 방향**은 두 가지가 있어요.
+
+1. **CSS 클래스를 지우고 HTML/JS에 Tailwind 유틸리티 문자열을 직접 쓰기.** 길어지긴 하지만 한 곳에서 전부 보여요.
+2. 정말 반복이 많은 경우에만 `buildInputField()`, `buildAdminButton()` 같은 **JS 컴포넌트 함수**로 묶기. 그러면 CSS 파일은 건드리지 않고, JS 함수가 Tailwind 클래스를 반환해요.
+
+요청사항처럼 **"CSS는 최소한, Tailwind 우선"** 원칙에 맞추려면 1번이 가장 깔끔해요. 세부 방법은 해결 가이드의 이슈 6을 참고해주세요.
+
+> 예외: `input[type='date']::-webkit-calendar-picker-indicator`, `::-webkit-scrollbar` 같이 **Tailwind로 표현할 수 없는 브라우저 전용 가상 요소**는 CSS로 쓰는 게 맞아요. 지금 `style.css`에 남아있는 게 딱 그런 것들이면 OK예요.
+
+---
+
+## 7. `admin/add/index.js`에 `console.log` 디버깅 로그가 남아있어요 (중요도: 낮음)
+
+**관련 파일:** `admin/add/index.js:182, 187, 193, 205`, `wishlist/index.js:49-50`
+
+```js
+// admin/add/index.js
+if (thumbnailFile !== null) {
+  console.log('대표 이미지 존재');     // ← 개발 중 로그
+  try {
+    const thumbnailUrl = await uploadImage(thumbnailFile);
+    ...
+  } catch (error) {
+    console.log(error.message);         // ← 개발 중 로그
+    toast.warn('썸네일 에러', error.message, 5);
+  }
+}
+```
+
+`console.log`는 개발 중에는 유용하지만 프로덕션 코드에는 남기지 않는 게 좋아요. 이유:
+
+- 사용자의 브라우저 콘솔에 의미 없는 메시지가 쌓여요.
+- 진짜 에러 로그와 섞여서 디버깅이 어려워져요.
+- `console.log(error.message)`는 이미 `toast.warn`이 같은 정보를 보여주니까 **중복**이에요.
+
+에러는 **한 곳에서만** 처리하는 게 좋아요. `toast.warn`을 쓸 거면 `console.log`는 지워요. 에러를 서버로 보내는 로깅이 필요하다면 `console.error`를 쓰고 목적을 분명히 해요.
+
+---
+
+## 8. `wishlist/index.js`가 엔드포인트 문자열을 직접 들고 있어요 (중요도: 낮음)
+
+**관련 파일:** `wishlist/index.js:35`
+
+```js
+async function fetchWishlist({ page } = {}) {
+  const params = new URLSearchParams({ pageLimit });
+  if (page) params.set('page', page);
+
+  const { data, meta } = await request(`/me/wishlist?${params}`, {
+    method: 'GET',
+  });
+
+  return { data, meta };
+}
+```
+
+이건 아주 큰 문제는 아니에요. `request()`를 잘 쓰고 있어요. 다만 `/me/wishlist`라는 **엔드포인트 문자열**이 페이지 파일 안에 있어요. 다른 예약 관련 API는 `src/api/reservation.js`에 모아 놓았는데, 위시리스트 전용 함수(`fetchWishlist`)만 페이지 안에 있어요.
+
+만약 백엔드가 엔드포인트를 `/me/wishlist` → `/users/me/wishlist`로 바꾼다면, 이 페이지 코드를 고쳐야 해요. 지금은 한 곳뿐이니 큰 문제가 아니지만, 위시리스트 페이지가 늘어나면 여러 곳을 고쳐야 해요.
+
+**해결 방향**은 `src/api/auth.js`에 `getWishlist({ page, pageLimit })` 함수를 추가하거나, `src/api/wishlist.js` 같은 모듈을 새로 만드는 거예요. 그러면 `wishlist/index.js`는 엔드포인트 문자열을 몰라도 돼요.
+
+---
+
+## 9. `admin/add/index.js` 상단의 모듈 전역 변수가 너무 많아요 (중요도: 낮음)
+
+**관련 파일:** `admin/add/index.js:32-44`
+
+```js
+let uploadThumbnailBtn = null;
+let deleteThumbnailBtn = null;
+let thumbnailInput = null;
+let preview = null;
+let uploadImagesBtn = null;
+let imagesInput = null;
+let imagesPreview = null;
+let imageMap = new Map();
+let thumbnailFile = null;
+let modal = null;
+let imageTitle = null;
+let imageDescription = null;
+let selectedImage = null;
+```
+
+13개의 모듈 전역 변수가 나열돼 있어요. 이 중 일부는 **썸네일 관련**, 일부는 **추가 이미지 관련**, 일부는 **모달 관련**이에요. 하지만 섞여 있어서 어떤 게 어떤 그룹에 속하는지 한눈에 안 보여요.
+
+**해결 방향**은 관련된 것끼리 객체로 묶는 거예요.
+
+```js
+const thumbnail = {
+  uploadBtn: null,
+  deleteBtn: null,
+  input: null,
+  preview: null,
+  file: null,
+};
+
+const images = {
+  uploadBtn: null,
+  input: null,
+  preview: null,
+  map: new Map(),
+};
+
+const modal = {
+  element: null,
+  title: null,
+  description: null,
+  selectedImage: null,
+};
+```
+
+이게 **응집도를 높이는** 전형적인 패턴이에요. 같은 목적을 가진 변수들을 한 객체로 묶으면, 나중에 "이미지 미리보기 기능을 제거하자"가 되면 `images` 객체만 지우면 돼요.
+
+---
+
+## 10. `accommodationForm.js`가 모듈 전역 상태를 쓰고 있어요 (중요도: 낮음)
+
+**관련 파일:** `src/components/accommodationForm.js:3-5`
+
+```js
+let originData = null;
+let modifiedData = null;
+let element = null;
+```
+
+`fetchAccommodation()`이 가져온 데이터를 모듈 전역 `originData`에 저장하고, `buildViewMode()`가 전역 `element`를 만들어서 반환해요. 이게 지금은 잘 돌아가는데, 한 페이지에서 동시에 두 개의 숙소 폼을 쓰려고 하면 **서로 값을 덮어써요**.
+
+이번 리뷰에서는 **지금 당장 고치라는 이슈는 아니에요.** 지금 구조에서는 한 페이지에 숙소 폼이 하나뿐이라 문제가 없어요. 다만 **"컴포넌트는 모듈 전역 상태 대신 클로저나 클래스를 쓰는 게 좋다"** 는 점만 기억해주세요. 이전 리뷰에서 소개한 `RoomCard` 클래스처럼요.
+
+---
+
+## 마무리
+
+- **결합도 낮추기**: 관리자 검증 중복(이슈 1), 에러 문자열 매칭(이슈 4), 자체 `getToken`(이슈 5) — 한 곳을 고치면 다른 곳이 자동으로 따라오게 만들어요.
+- **응집도 높이기**: 모달 공통화(이슈 2), 삭제 버튼 공통화(이슈 3), 전역 변수 그룹핑(이슈 9) — 같은 목적의 코드를 같은 곳에 모아요.
+- **Tailwind 원칙**: `@apply`로 만든 커스텀 클래스 최소화(이슈 6) — 마크업만 봐도 스타일을 알 수 있게.
+- **프로덕션 청소**: 불필요한 `console.log` 제거(이슈 7) — 작지만 중요한 습관이에요.
+
+처음 리뷰했을 때와 비교하면 이번 리팩토링에서 코드 구조가 정말 많이 개선됐어요. 이번 리뷰의 이슈들은 **"잘 만든 다음 단계의 개선"** 이에요. 계속해서 "같은 코드를 두 번 쓰지 않기", "한 곳에서 한 가지 일만 하기" 원칙을 지키면 돼요.
+
+수정 작업을 시작할 때는 [review-20260414_해결.md](./review-20260414_해결.md)를 같이 열어두고 순서대로 진행해주세요.

--- a/docs/review-20260414_해결.md
+++ b/docs/review-20260414_해결.md
@@ -1,0 +1,901 @@
+# 코드 리뷰 해결 가이드 (2026-04-14)
+
+> 리뷰 날짜: 2026-04-14
+> 대상: Latte_BnB (에어비앤비 클론 코딩 프로젝트)
+> 원본 리뷰: [review-20260414.md](./review-20260414.md)
+
+---
+
+## 수정 작업을 시작하기 전에
+
+이슈 사이에 의존 관계가 있어요. 아래 순서를 따르면 충돌 없이 진행할 수 있어요.
+
+1. **이슈 4** (에러 상태 코드 구조화) — `src/api/client.js`를 먼저 고쳐야 다른 페이지에서 이걸 쓸 수 있어요.
+2. **이슈 1** (관리자 검증 유틸) — `src/api/auth.js`에 함수를 추가하고 `admin/*` 3곳을 고쳐요.
+3. **이슈 2** (모달 공통 컴포넌트) — `src/components/modal.js`를 만들고 각 페이지에서 사용해요.
+4. **이슈 3** (삭제 버튼 공통 컴포넌트) — `src/components/deleteButton.js` 생성 후 `admin/*` 두 곳에서 사용.
+5. **이슈 5, 6, 7, 8, 9** (개별 파일 개선) — 서로 독립적이라 순서 상관없이 진행 가능.
+
+각 이슈마다 **"왜 이렇게 고치는지"**와 **"수정 전/후 코드"**를 나란히 놓았어요. 수정 전 코드와 정확히 같지 않다면, 여러분의 파일을 기준으로 패턴만 따라해주세요.
+
+---
+
+## 이슈 1: 관리자 권한 검증을 공통 유틸 함수로 통합하기
+
+### 왜 고쳐야 할까요
+
+`admin/index.js`, `admin/add/index.js`, `admin/accommodation/index.js` 세 파일에 **같은 검증 로직**이 복사되어 있어요. 하나를 고치면 나머지 두 개도 같이 고쳐야 하는데, 사람이 하면 꼭 하나씩 빠뜨려요. 이런 걸 "결합도가 높다"고 해요.
+
+**목표**: "사용자가 관리자인지 확인하는 일"을 **한 곳에서만** 처리하기. 각 페이지는 그 함수를 호출만 하기.
+
+### 수정 파일 1: `src/api/auth.js`에 `ensureAdmin` 함수 추가
+
+`getProfile` 아래 아무 곳에 함수를 추가해요.
+
+```js
+// src/api/auth.js에 추가
+export async function ensureAdmin() {
+  try {
+    const res = await getProfile();
+    if (!res || res.data.user.role !== 'ADMIN') {
+      return false;
+    }
+    return res.data.user;
+  } catch {
+    return false;
+  }
+}
+```
+
+이 함수의 **약속**은 이렇게 정리할 수 있어요.
+
+- 관리자면 `user` 객체를 반환해요.
+- 관리자가 아니거나 로그인도 안 됐으면 `false`를 반환해요.
+- 에러를 던지지 않아요. 호출하는 쪽이 `if (!admin)`만 체크하면 돼요.
+
+### 수정 파일 2: `admin/index.js`
+
+```js
+// 수정 전 (18~29번째 줄)
+const profilePromise = getProfile();
+
+profilePromise
+  .then(({ data }) => {
+    if (data.user.role !== 'ADMIN') {
+      throw new Error();
+    }
+    content.classList.replace('hidden', 'grid');
+  })
+  .catch(() => {
+    location.replace('/admin/login/');
+  });
+```
+
+```js
+// 수정 후
+import { ensureAdmin } from '../src/api/auth';
+
+const admin = await ensureAdmin();
+if (!admin) {
+  location.replace('/admin/login/');
+} else {
+  content.classList.replace('hidden', 'grid');
+}
+```
+
+import 목록에서 `getProfile`이 더 이상 쓰이지 않으면 지워요. 그리고 import 구문에 `ensureAdmin`을 추가해요.
+
+### 수정 파일 3: `admin/add/index.js`
+
+같은 방식으로 바꿔요.
+
+```js
+// 수정 전 (19~30번째 줄)
+const profilePromise = getProfile();
+
+profilePromise
+  .then(({ data }) => {
+    if (data.user.role !== 'ADMIN') {
+      throw new Error();
+    }
+    content.classList.replace('hidden', 'grid');
+  })
+  .catch(() => {
+    location.replace('/admin/login/');
+  });
+```
+
+```js
+// 수정 후
+import { ensureAdmin } from '../../src/api/auth.js';
+
+const admin = await ensureAdmin();
+if (!admin) {
+  location.replace('/admin/login/');
+} else {
+  content.classList.replace('hidden', 'grid');
+}
+```
+
+### 수정 파일 4: `admin/accommodation/index.js`
+
+```js
+// 수정 전 (15~25번째 줄)
+const profilePromise = getProfile();
+
+profilePromise
+  .then(({ data }) => {
+    if (data.user.role !== 'ADMIN') {
+      throw new Error();
+    }
+  })
+  .catch(() => {
+    location.replace('/admin/login/');
+  });
+```
+
+```js
+// 수정 후
+import { ensureAdmin } from '../../src/api/auth.js';
+
+const admin = await ensureAdmin();
+if (!admin) {
+  location.replace('/admin/login/');
+}
+```
+
+이 파일은 원래 `content.classList.replace`를 하지 않고, 대신 `fetchPromise.then` 안에서 `classList.replace`를 해요. 그래서 성공 분기에서 할 일이 없어요. 위 코드에서는 성공 시 아무것도 하지 않아요.
+
+### 결과
+
+- 관리자 검증 로직이 **`src/api/auth.js` 한 곳**에만 있어요.
+- 나중에 리다이렉트 경로를 `/admin/signin/`으로 바꾸고 싶으면 `admin/index.js`, `admin/add/index.js`, `admin/accommodation/index.js` 세 곳을 고쳐야 해요. 함수 내부는 건드리지 않아도 돼요. (더 나아가서 리다이렉트도 `ensureAdmin` 안에 넣을 수도 있지만, "이 함수가 하는 일이 너무 많아진다" 싶으면 그대로 두는 게 나아요.)
+
+---
+
+## 이슈 2: 모달 열기/닫기를 공통 컴포넌트로 만들기
+
+### 왜 고쳐야 할까요
+
+모달을 여닫는 방법이 페이지마다 달라요. 어떤 곳은 `hidden`/`flex`를, 어떤 곳은 `invisible`/`visible`을, 어떤 곳은 `active` 클래스를 써요. 이걸 통일하지 않으면 "우리 프로젝트에서 모달은 어떻게 여는 거지?"라는 질문의 답이 5개가 돼요.
+
+**목표**: `src/components/modal.js`에 `openModal(el)`, `closeModal(el)` 두 함수만 만들고, 모든 모달 HTML이 같은 클래스를 사용하게 하기.
+
+### 설계 결정: 어떤 클래스를 표준으로 할까?
+
+Tailwind 원칙에 잘 맞는 건 `hidden`/`flex` 방식이에요. 이유:
+
+- `hidden`은 Tailwind가 기본 제공해요. 커스텀 CSS가 필요 없어요.
+- HTML 마크업만 봐도 "기본 상태는 숨김"이라는 게 바로 보여요.
+- `flex`/`grid`로 여는 방식도 Tailwind 클래스라서 커스텀 CSS가 필요 없어요.
+
+그래서 이렇게 통일할게요:
+
+- **닫힌 상태**: `hidden` 클래스 포함.
+- **열린 상태**: `hidden` 제거 + `flex` 추가 + `<body>`에 `overflow-hidden` 추가 (배경 스크롤 막기).
+
+### 수정 파일 1: `src/components/modal.js` 새로 만들기
+
+```js
+// src/components/modal.js (새 파일)
+export function openModal(element) {
+  if (!element) return;
+  element.classList.remove('hidden');
+  element.classList.add('flex');
+  document.body.classList.add('overflow-hidden');
+}
+
+export function closeModal(element) {
+  if (!element) return;
+  element.classList.remove('flex');
+  element.classList.add('hidden');
+  document.body.classList.remove('overflow-hidden');
+}
+```
+
+단 10줄짜리 파일이지만, 이걸 만드는 것만으로 **"모달은 이렇게 여닫습니다"가 프로젝트 전체에 공유돼요.**
+
+### 수정 파일 2: `reservation-request/reservation-request.js`
+
+```js
+// 수정 전 (173~183번째 줄)
+function openModal(modal) {
+  modal.classList.remove('hidden');
+  modal.classList.add('flex');
+  document.body.classList.add('overflow-hidden');
+}
+
+function closeModal(modal) {
+  modal.classList.remove('flex');
+  modal.classList.add('hidden');
+  document.body.classList.remove('overflow-hidden');
+}
+```
+
+```js
+// 수정 후
+import { openModal, closeModal } from '../src/components/modal.js';
+
+// 함수 정의 부분을 통째로 지우세요.
+```
+
+나머지 `openModal(calModal)`, `closeModal(calModal)` 호출 부분은 그대로 둬요. 함수 이름이 같으니까요.
+
+### 수정 파일 3: `profile/profile.js`
+
+이 파일은 `withdrawModal.classList.add('active')`를 써요. 먼저 HTML을 고치고 JS를 고쳐요.
+
+**HTML 수정 (`profile/index.html`)**
+
+```html
+<!-- 수정 전 -->
+<div
+  id="withdrawModal"
+  class="fixed inset-0 bg-black/50 flex items-center justify-center opacity-0 invisible transition-opacity duration-300 [&.active]:opacity-100 [&.active]:visible">
+```
+
+```html
+<!-- 수정 후 -->
+<div
+  id="withdrawModal"
+  class="hidden fixed inset-0 bg-black/50 items-center justify-center">
+```
+
+`opacity-0 invisible` 대신 `hidden`을 쓰고, 기본 상태를 숨김으로 만들어요. `[&.active]:...` 같은 variant는 더 이상 필요 없어요. `transition-opacity`가 필요했다면 아쉽지만 `hidden`은 트랜지션을 지원하지 않아요. 자연스러운 페이드가 꼭 필요하면 `openModal`/`closeModal`을 `flex`/`opacity-100` 조합으로 바꾸는 방법도 있어요. 지금은 단순하게 갈게요.
+
+**JS 수정 (`profile/profile.js`)**
+
+```js
+// 수정 전 (82, 86번째 줄)
+document.getElementById('withdrawBtn').addEventListener('click', () => {
+  withdrawPassword.value = '';
+  withdrawModal.classList.add('active');
+});
+
+document.getElementById('withdrawCancel').addEventListener('click', () => {
+  withdrawModal.classList.remove('active');
+});
+```
+
+```js
+// 수정 후
+import { openModal, closeModal } from '../src/components/modal.js';
+
+document.getElementById('withdrawBtn').addEventListener('click', () => {
+  withdrawPassword.value = '';
+  openModal(withdrawModal);
+});
+
+document.getElementById('withdrawCancel').addEventListener('click', () => {
+  closeModal(withdrawModal);
+});
+```
+
+`withdrawOk` 클릭 핸들러에서 탈퇴 완료 후에도 `closeModal(withdrawModal)`을 호출하도록 추가해주면 더 깔끔해요.
+
+### 수정 파일 4: `login/index.js` / `signup/index.js`
+
+이 두 파일은 `modalContainer`에 `invisible`/`visible`/`opacity-0`/`opacity-100`을 토글해요. 위처럼 HTML을 `hidden` 기반으로 바꾸고, JS에서는 `openModal(modal.modalContainer)`을 호출해요.
+
+**HTML 수정 (`login/index.html`, `signup/index.html` 각각)**
+
+```html
+<!-- 수정 전 -->
+<div
+  id="modalContainer"
+  class="fixed inset-0 flex items-center justify-center bg-[color-mix(in_oklab,var(--color-black)_50%,transparent)] transition-opacity duration-300 ease-[ease] invisible opacity-0">
+```
+
+```html
+<!-- 수정 후 -->
+<div
+  id="modalContainer"
+  class="hidden fixed inset-0 items-center justify-center bg-[color-mix(in_oklab,var(--color-black)_50%,transparent)]">
+```
+
+**JS 수정 (`login/index.js`)**
+
+```js
+// 수정 전 (104~105번째 줄)
+modal.modalContainer.classList.remove('invisible', 'opacity-0');
+modal.modalContainer.classList.add('visible', 'opacity-100');
+```
+
+```js
+// 수정 후
+import { openModal } from '../src/components/modal.js';
+// ...
+openModal(modal.modalContainer);
+```
+
+`signup/index.js`도 같은 방식이에요.
+
+### 수정 파일 5: `reservations-detail/index.js` (가장 복잡)
+
+이 파일의 `openModal`, `closeModal`, `openModalReverse`, `closeModalReverse`, `errorModal`, `errorModalReverse` 6개 함수는 **서로 다른 모달 3개**를 각각 열고 닫아요. 이름이 혼란스러워서 리뷰 때 지적했어요.
+
+가장 안전한 리팩토링은 한 모달씩 바꾸는 거예요.
+
+```js
+// 수정 후 (권장)
+import { openModal, closeModal } from '../src/components/modal.js';
+
+// 지역 함수(openModal, closeModal, openModalReverse, closeModalReverse, errorModal, errorModalReverse)를 모두 지우세요.
+
+elements.cancel.addEventListener('click', () => {
+  elements.modalContainer.classList.remove('invisible', 'opacity-0');
+  elements.modalContainer.classList.add('visible', 'opacity-100');
+  document.body.classList.add('overflow-hidden');
+  openModal(elements.cancelModal);
+  closeModal(elements.cancelConfirmModal);
+  closeModal(elements.cancelFaultModal);
+});
+
+elements.cancelNo.addEventListener('click', () => {
+  elements.modalContainer.classList.remove('visible', 'opacity-100');
+  elements.modalContainer.classList.add('invisible', 'opacity-0');
+  document.body.classList.remove('overflow-hidden');
+  closeModal(elements.cancelModal);
+});
+
+elements.cancelYes.addEventListener('click', async () => {
+  try {
+    await removeReservation(reservationId);
+    closeModal(elements.cancelModal);
+    openModal(elements.cancelConfirmModal);
+  } catch (e) {
+    closeModal(elements.cancelModal);
+    openModal(elements.cancelFaultModal);
+    elements.cancelFault.textContent = `예약을 취소하지 못했습니다.\n다시 시도해주세요.`;
+  }
+});
+```
+
+**핵심**: 더 이상 `openModalReverse` 같은 이름이 없어요. 어떤 모달을 열고 어떤 모달을 닫는지 `openModal(elements.cancelModal)`, `closeModal(elements.cancelFaultModal)`처럼 **이름 그대로** 읽혀요. HTML에서도 각 모달의 초기 상태를 `hidden`으로 바꿔야 해요.
+
+### 결과
+
+- 모달 토글 방법이 **한 가지**로 통일됐어요.
+- 새 페이지에서 모달을 만들 때는 `import { openModal, closeModal } ...`만 하면 돼요.
+- HTML에서는 `hidden` 클래스를 기본값으로 쓰니까 마크업만 봐도 상태를 알 수 있어요.
+
+---
+
+## 이슈 3: 삭제 버튼을 공통 컴포넌트로 만들기
+
+### 왜 고쳐야 할까요
+
+`admin/index.js`와 `admin/accommodation/index.js`에 같은 SVG 휴지통 아이콘이 복사되어 있어요. 휴지통 디자인이 바뀌면 두 파일 다 고쳐야 하는데, 하나 빼먹으면 목록과 상세에서 아이콘이 달라져요.
+
+### 수정 파일 1: `src/components/deleteButton.js` 새로 만들기
+
+```js
+// src/components/deleteButton.js (새 파일)
+export function buildDeleteButton(extraClassName = '') {
+  const btn = document.createElement('button');
+  btn.className = [
+    'deleteAccommodationBtn',
+    'bg-primary-500 text-white hover:bg-primary-500/75 p-1 rounded-xl',
+    extraClassName,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  btn.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6 pointer-events-none">
+      <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+    </svg>
+  `;
+  return btn;
+}
+```
+
+**요점**: 공통 부분(색상, 크기, SVG)은 함수 안에 고정하고, 페이지마다 다른 부분(위치 관련 `absolute top-2 right-2` 같은 것, 또는 `w-8 h-8`)은 매개변수로 받아요.
+
+### 수정 파일 2: `admin/index.js`
+
+```js
+// 수정 전 (70~80번째 줄 — 함수 정의)
+function buildDeleteBtn() {
+  const btn = document.createElement('button');
+  btn.className = 'deleteAccommodationBtn absolute bg-primary-500 text-white top-2 right-2 hover:bg-primary-500/75 p-1 rounded-xl';
+  btn.innerHTML = `...`;
+  return btn;
+}
+
+// 함수 호출 부분 (56번째 줄)
+li.appendChild(buildDeleteBtn());
+```
+
+```js
+// 수정 후
+import { buildDeleteButton } from '../src/components/deleteButton.js';
+
+// 함수 정의는 통째로 삭제하세요.
+
+// 호출 부분 (56번째 줄)
+li.appendChild(buildDeleteButton('absolute top-2 right-2'));
+```
+
+### 수정 파일 3: `admin/accommodation/index.js`
+
+```js
+// 수정 전 (50~60번째 줄 — 함수 정의)
+function buildDeleteBtn() { ... }
+
+// 호출 부분 (35번째 줄)
+btnContainer.appendChild(buildDeleteBtn());
+```
+
+```js
+// 수정 후
+import { buildDeleteButton } from '../../src/components/deleteButton.js';
+
+// 함수 정의는 통째로 삭제하세요.
+
+// 호출 부분 (35번째 줄)
+btnContainer.appendChild(buildDeleteButton('w-8 h-8'));
+```
+
+### 결과
+
+- SVG path 문자열이 **한 파일에만** 존재해요.
+- 휴지통 디자인이 바뀌면 `src/components/deleteButton.js`만 고치면 돼요.
+- 페이지별로 다른 위치(`absolute ...`)는 매개변수로 명시해서 읽기 쉬워요.
+
+---
+
+## 이슈 4: 에러 상태 코드를 구조화하기
+
+### 왜 고쳐야 할까요
+
+`if (error.message === 'HTTP 에러: 401')` 같은 문자열 비교는 **구현 세부사항에 의존**해요. `client.js`가 메시지를 살짝 바꾸면 `profile.js`, `reservation-request.js`가 조용히 망가져요.
+
+**목표**: 에러에 `status` 프로퍼티를 붙이고, 호출하는 쪽에서 `error.status === 401`로 체크하기.
+
+### 수정 파일 1: `src/api/client.js`
+
+```js
+// 수정 전 (22~27번째 줄)
+if (!res.ok) {
+  const { message } = await res.json();
+  const error = new Error(`HTTP 에러: ${res.status}`);
+  error.data = { message };
+  throw error;
+}
+```
+
+```js
+// 수정 후
+if (!res.ok) {
+  let message = '';
+  try {
+    ({ message } = await res.json());
+  } catch {
+    // 서버가 JSON을 안 보내면 무시
+  }
+  const error = new Error(`HTTP 에러: ${res.status}`);
+  error.status = res.status;      // ← 추가
+  error.data = { message };
+  throw error;
+}
+```
+
+한 줄 추가(`error.status = res.status;`)로 호출하는 쪽에서 숫자 비교가 가능해져요. `try/catch`로 감싼 건 서버가 JSON이 아닌 응답을 주는 경우(예: HTML 에러 페이지)를 대비한 거예요.
+
+`imageRequest`도 같은 방식으로 바꾸면 더 좋지만, 지금은 이미지 업로드에서 401 분기가 필요하지 않으니 일단 `request`만 고쳐요.
+
+### 수정 파일 2: `profile/profile.js`
+
+```js
+// 수정 전 (33번째 줄)
+if (error.message === 'HTTP 에러: 401') {
+  alert('로그인을 먼저 해주세요');
+  location.href = '/login/';
+  return;
+}
+```
+
+```js
+// 수정 후
+if (error.status === 401) {
+  alert('로그인을 먼저 해주세요');
+  location.href = '/login/';
+  return;
+}
+```
+
+### 수정 파일 3: `reservation-request/reservation-request.js`
+
+```js
+// 수정 전 (22번째 줄)
+if (error.message === 'HTTP 에러: 401') {
+  alert('로그인이 필요합니다.');
+  location.href = '/login/';
+}
+```
+
+```js
+// 수정 후
+if (error.status === 401) {
+  alert('로그인이 필요합니다.');
+  location.href = '/login/';
+}
+```
+
+### 결과
+
+- 에러 메시지 문자열이 바뀌어도 호출하는 쪽 코드는 영향받지 않아요.
+- 나중에 403(권한 없음) 처리를 추가하고 싶으면 `if (error.status === 403)`만 쓰면 돼요.
+
+---
+
+## 이슈 5: `reservations-detail`의 자체 `getToken` 삭제
+
+### 왜 고쳐야 할까요
+
+프로젝트에는 이미 `src/utils/auth.js`에 `getToken`이 있어요. 이 파일만 localStorage를 직접 들여다보는 자기만의 `getToken`을 가지고 있어요. 나중에 토큰 저장소를 바꾸면 이 파일만 외톨이가 돼요.
+
+### 수정 파일: `reservations-detail/index.js`
+
+```js
+// 수정 전 (1~12번째 줄)
+import {
+  getReservationDetail,
+  removeReservation,
+} from '../src/api/reservation.js';
+
+const storageKeys = {
+  token: 'accessToken',
+};
+
+function getToken() {
+  return localStorage.getItem(storageKeys.token);
+}
+```
+
+```js
+// 수정 후
+import {
+  getReservationDetail,
+  removeReservation,
+} from '../src/api/reservation.js';
+import { getToken } from '../src/utils/auth.js';
+```
+
+단 3줄을 지우고 1줄을 import에 추가하면 끝이에요. 116번째 줄의 `const token = getToken();`은 이제 `src/utils/auth.js`의 함수를 호출해요.
+
+---
+
+## 이슈 6: `style.css`의 `@apply` 커스텀 클래스 정리
+
+### 왜 고쳐야 할까요
+
+`.adminThumbnailUpload` 같은 이름이 **HTML, CSS, JS** 세 곳에 모두 있어야 동작해요. 하나가 빠지거나 오타가 나면 조용히 깨져요. Tailwind 본래의 장점(마크업만 보고 스타일 이해하기)도 사라져요.
+
+### 설계 결정
+
+이번에는 **가장 단순한 접근**을 써요: CSS 커스텀 클래스를 지우고, 같은 스타일을 HTML/JS에 Tailwind 유틸리티 문자열로 직접 써요.
+
+길어지는 걸 걱정할 수 있는데, Tailwind 프로젝트에서 이게 정상이에요. 한눈에 보이는 게 더 중요해요.
+
+### 수정 파일 1: `src/style.css`
+
+```css
+/* 수정 전 (141~156번째 줄) */
+.adminInputText,
+.adminInputNumber,
+.adminInputDate {
+  @apply border-shark-50 text-white border-1 h-10 px-4 py-2 rounded-md focus:outline-primary-500 placeholder:text-shark-100 my-2;
+}
+.adminLabel {
+  @apply font-semibold text-white text-lg;
+}
+.adminThumbnailUpload,
+.adminImagesUpload {
+  @apply bg-shark-700/20 w-full max-w-90 rounded-2xl aspect-square hover:bg-shark-700/15;
+}
+.adminThumbnailModify {
+  @apply w-full h-fit bg-primary-500 rounded-2xl p-1 my-2 hover:bg-primary-500/70;
+}
+```
+
+이 15줄을 **통째로 지워요.** `style.css`는 이제 테마 정의, 브라우저 전용 가상 요소, `thin-scroll` 유틸리티만 남아요.
+
+### 수정 파일 2: `admin/add/index.html`
+
+이 파일에서 `class="adminInputText"`, `class="adminLabel"`, `class="adminThumbnailUpload"`, `class="adminImagesUpload"`를 찾아서 대응되는 Tailwind 문자열로 바꿔요.
+
+예시:
+
+```html
+<!-- 수정 전 -->
+<label class="adminLabel">숙소 이름</label>
+<input class="adminInputText" name="title" />
+
+<!-- 수정 후 -->
+<label class="font-semibold text-white text-lg">숙소 이름</label>
+<input
+  class="border-shark-50 text-white border-1 h-10 px-4 py-2 rounded-md focus:outline-primary-500 placeholder:text-shark-100 my-2"
+  name="title" />
+```
+
+Tailwind 클래스가 너무 길다고 느낀다면, HTML 안에서 여러 줄로 쪼개 써도 돼요.
+
+```html
+<input
+  class="border-shark-50 text-white border-1 h-10 px-4 py-2 rounded-md
+         focus:outline-primary-500 placeholder:text-shark-100 my-2"
+  name="title" />
+```
+
+### 수정 파일 3: `admin/add/index.js`
+
+`className = 'adminThumbnailModify'` 같은 부분을 Tailwind 문자열로 바꿔요.
+
+```js
+// 수정 전 (52번째 줄)
+uploadThumbnailBtn.className = 'adminThumbnailModify';
+```
+
+```js
+// 수정 후
+uploadThumbnailBtn.className =
+  'w-full h-fit bg-primary-500 rounded-2xl p-1 my-2 hover:bg-primary-500/70';
+```
+
+```js
+// 수정 전 (65번째 줄)
+uploadThumbnailBtn.className = 'adminThumbnailUpload';
+```
+
+```js
+// 수정 후
+uploadThumbnailBtn.className =
+  'bg-shark-700/20 w-full max-w-90 rounded-2xl aspect-square hover:bg-shark-700/15';
+```
+
+**정말 너무 길어서 반복이 싫다면**, JS 파일 상단에 상수로 뽑아도 돼요.
+
+```js
+const THUMBNAIL_UPLOAD_CLASS =
+  'bg-shark-700/20 w-full max-w-90 rounded-2xl aspect-square hover:bg-shark-700/15';
+const THUMBNAIL_MODIFY_CLASS =
+  'w-full h-fit bg-primary-500 rounded-2xl p-1 my-2 hover:bg-primary-500/70';
+
+// ...
+uploadThumbnailBtn.className = THUMBNAIL_MODIFY_CLASS;
+```
+
+이건 **CSS 파일을 건드리지 않고 JS 안에서만** 스타일 상수를 쓰는 방식이에요. Tailwind의 원칙(유틸리티 클래스)에는 부합해요.
+
+### 결과
+
+- `style.css`는 **Tailwind로 표현할 수 없는 것만** 담고 있어요.
+- HTML이나 JS에 Tailwind 클래스 문자열이 직접 있어요. 스타일이 어디서 오는지 한눈에 보여요.
+
+---
+
+## 이슈 7: `console.log` 정리
+
+### 왜 고쳐야 할까요
+
+프로덕션 코드에 `console.log`가 남아있으면 사용자 콘솔이 지저분해지고, 진짜 에러와 섞여서 디버깅이 어려워져요.
+
+### 수정 파일 1: `admin/add/index.js`
+
+```js
+// 수정 전 (182, 187, 193, 205번째 줄)
+if (thumbnailFile !== null) {
+  console.log('대표 이미지 존재');                 // ← 지우기
+  try {
+    const thumbnailUrl = await uploadImage(thumbnailFile);
+    requestData.thumbnailUrl = thumbnailUrl;
+  } catch (error) {
+    console.log(error.message);                    // ← 지우기
+    toast.warn('썸네일 에러', error.message, 5);
+  }
+}
+
+if (imageMap.size > 0) {
+  console.log('추가 이미지 존재');                 // ← 지우기
+  requestData.images = [];
+  try {
+    for (const value of imageMap.values()) {
+      // ...
+    }
+  } catch (error) {
+    console.log(error.message);                    // ← 지우기
+    toast.warn('이미지 에러', error.message, 5);
+  }
+}
+```
+
+`console.log` 4줄을 모두 지워요. `toast.warn`이 이미 사용자에게 에러를 보여주고 있어요.
+
+### 수정 파일 2: `wishlist/index.js`
+
+```js
+// 수정 전 (49~50번째 줄)
+} catch (error) {
+  console.log('찜 일괄 체크 실패');
+  console.log(error.message);
+  return;
+}
+```
+
+```js
+// 수정 후
+} catch {
+  // 찜 상태 체크 실패는 조용히 넘어감 — 로그인하지 않은 사용자일 수 있음
+  return;
+}
+```
+
+에러 객체를 쓰지 않으면 `catch` 괄호 자체를 생략할 수 있어요(최신 ES 문법). 그리고 **"왜 조용히 넘어가는지"** 를 한 줄 주석으로 남겨두면, 나중에 누가 "이거 에러 처리 빠진 거 아닌가?" 하고 의심할 때 답이 돼요.
+
+---
+
+## 이슈 8: `wishlist` API 모듈로 분리 (선택 사항)
+
+### 왜 고쳐야 할까요
+
+`/me/wishlist` 엔드포인트 문자열이 `wishlist/index.js` 안에 있어요. 위시리스트 기능이 커지면 여러 페이지에서 이 엔드포인트를 알아야 해요.
+
+### 수정 파일 1: `src/api/auth.js`에 함수 추가
+
+```js
+// src/api/auth.js에 추가
+export async function getWishlist({ page, pageLimit = 20 } = {}) {
+  const params = new URLSearchParams({ pageLimit });
+  if (page) params.set('page', page);
+
+  return authRequest(`/me/wishlist?${params}`);
+}
+```
+
+`getWishlist`는 로그인이 필수이니 `authRequest`가 자연스러워요.
+
+### 수정 파일 2: `wishlist/index.js`
+
+```js
+// 수정 전 (5~6번째 줄, 28~40번째 줄)
+import { checkWish, getProfile } from '../src/api/auth.js';
+import { request } from '../src/api/client.js';
+
+// ...
+
+async function fetchWishlist({ page } = {}) {
+  const params = new URLSearchParams({ pageLimit });
+  if (page) params.set('page', page);
+
+  const { data, meta } = await request(`/me/wishlist?${params}`, {
+    method: 'GET',
+  });
+
+  return { data, meta };
+}
+```
+
+```js
+// 수정 후
+import { checkWish, getProfile, getWishlist } from '../src/api/auth.js';
+
+// ...
+
+async function fetchWishlist({ page } = {}) {
+  return getWishlist({ page, pageLimit });
+}
+```
+
+아예 `fetchWishlist`를 지우고 호출하는 곳에서 `getWishlist`를 직접 써도 돼요. 취향에 따라 선택해요.
+
+### 결과
+
+- 위시리스트 API 경로가 `src/api/auth.js` (또는 새 `wishlist.js`) 한 곳에만 있어요.
+- `wishlist/index.js`는 "UI를 어떻게 그릴지"에만 집중해요.
+
+---
+
+## 이슈 9: `admin/add/index.js` 전역 변수 그룹핑 (선택 사항)
+
+### 왜 고쳐야 할까요
+
+13개의 `let`이 나열되어 있어서 어떤 변수가 어떤 기능에 속하는지 파악하기 어려워요.
+
+### 수정 파일: `admin/add/index.js`
+
+```js
+// 수정 전 (32~44번째 줄)
+let uploadThumbnailBtn = null;
+let deleteThumbnailBtn = null;
+let thumbnailInput = null;
+let preview = null;
+let uploadImagesBtn = null;
+let imagesInput = null;
+let imagesPreview = null;
+let imageMap = new Map();
+let thumbnailFile = null;
+let modal = null;
+let imageTitle = null;
+let imageDescription = null;
+let selectedImage = null;
+```
+
+```js
+// 수정 후
+const thumbnail = {
+  uploadBtn: null,
+  deleteBtn: null,
+  input: null,
+  preview: null,
+  file: null,
+};
+
+const images = {
+  uploadBtn: null,
+  input: null,
+  preview: null,
+  map: new Map(),
+};
+
+const imageModal = {
+  element: null,
+  title: null,
+  description: null,
+  selected: null,
+};
+```
+
+이제 DOM 로딩 뒤에 ID를 찾는 부분도 그룹별로 묶어요.
+
+```js
+// 수정 전 (93~103번째 줄)
+uploadThumbnailBtn = document.getElementById('uploadThumbnail');
+deleteThumbnailBtn = document.getElementById('deleteThumbnail');
+thumbnailInput = document.getElementById('thumbnail');
+preview = document.getElementById('preview');
+uploadImagesBtn = document.getElementById('uploadImagesBtn');
+imagesInput = document.getElementById('images');
+imagesPreview = document.getElementById('imagesPreview');
+modal = document.getElementById('modal');
+imageTitle = document.getElementById('imageTitle');
+imageDescription = document.getElementById('imageDescription');
+selectedImage = document.getElementById('selectedImage');
+```
+
+```js
+// 수정 후
+thumbnail.uploadBtn = document.getElementById('uploadThumbnail');
+thumbnail.deleteBtn = document.getElementById('deleteThumbnail');
+thumbnail.input = document.getElementById('thumbnail');
+thumbnail.preview = document.getElementById('preview');
+
+images.uploadBtn = document.getElementById('uploadImagesBtn');
+images.input = document.getElementById('images');
+images.preview = document.getElementById('imagesPreview');
+
+imageModal.element = document.getElementById('modal');
+imageModal.title = document.getElementById('imageTitle');
+imageModal.description = document.getElementById('imageDescription');
+imageModal.selected = document.getElementById('selectedImage');
+```
+
+그리고 파일 전체에서 `uploadThumbnailBtn` → `thumbnail.uploadBtn`, `thumbnailFile` → `thumbnail.file`, `imageMap` → `images.map` 등으로 바꿔요. 조금 번거롭지만 "대체(Replace All)" 기능으로 한 번에 바꿀 수 있어요.
+
+**주의**: 파일 바꿀 때 같은 이름이 다른 곳에서도 쓰이지 않는지 확인해요. 예를 들어 `modal`이라는 이름은 너무 일반적이라서 `imageModal`로 바꿨어요. 그래야 다른 모달 유틸과 충돌하지 않아요.
+
+### 결과
+
+- 관련된 변수들이 객체로 묶여서 **응집도가 높아져요**.
+- "썸네일 기능 삭제하자"가 되면 `thumbnail` 객체와 관련 코드만 지우면 돼요.
+
+---
+
+## 마무리
+
+한 번에 다 하려고 하지 말고, **한 이슈씩** 해결하고 브라우저로 동작 확인 후 다음 이슈로 넘어가세요. 이슈 하나 고치고 `vite dev`로 실행해서 관련 페이지를 직접 클릭해보는 것까지가 한 세트예요.
+
+특히 이슈 2(모달)와 이슈 6(Tailwind 정리)은 수정 범위가 넓으니까 **이슈별로 커밋**을 따로 남기면 나중에 문제가 생겼을 때 어디서 깨졌는지 찾기 쉬워요.
+
+잘 해내실 수 있을 거예요! 궁금한 점이 있으면 언제든 질문해주세요.


### PR DESCRIPTION
## Summary
- 최근 리팩토링(공통 `client.js`/`auth.js` 정착, 관리자 마크업 개선, 로그인·회원가입 모달, reservation-request 공통화 등) 이후 시점의 코드 리뷰 문서 2종을 추가합니다.
- 이번 리뷰의 초점은 **결합도(Coupling) 낮추기**와 **응집도(Cohesion) 높이기**입니다. 초보 개발자 대상으로 친절한 설명을 지향했습니다.

## 포함 파일
- `docs/review-20260414.md` — 10개 이슈에 대한 리뷰 (중요도·원인·영향 포함)
- `docs/review-20260414_해결.md` — 이슈별 수정 전/후 코드와 단계별 가이드

## 주요 리뷰 포인트
1. **관리자 권한 검증 중복** — `admin/index.js`, `admin/add/index.js`, `admin/accommodation/index.js` 세 곳이 동일한 `getProfile` 검증 블록을 복사함 → `src/api/auth.js`에 `ensureAdmin()` 신설 제안
2. **모달 열기/닫기 방식 혼재** — `login`, `signup`, `reservation-request`, `profile`, `reservations-detail`가 각자 다른 클래스(`invisible`, `hidden`, `active`)를 토글 → `src/components/modal.js` 공통 함수 제안
3. **삭제 버튼 SVG 중복** — `admin/index.js` vs `admin/accommodation/index.js` → `src/components/deleteButton.js` 제안
4. **에러 문자열 매칭** — `error.message === 'HTTP 에러: 401'` 의존 → `client.js`에 `error.status` 구조화 제안
5. **`reservations-detail/index.js`가 자체 `getToken` 재구현** → `src/utils/auth.js` 사용으로 통일
6. **`style.css`의 `@apply` 커스텀 admin 클래스** — Tailwind 원칙 위반 → HTML/JS에 유틸리티 직접 사용 제안
7. **프로덕션 `console.log` 잔존** (`admin/add/index.js`, `wishlist/index.js`)
8. **`wishlist` 엔드포인트 분산** — `src/api/auth.js`로 이동 제안 (선택)
9. **`admin/add/index.js` 13개 전역 변수** — `thumbnail`/`images`/`imageModal` 객체로 그룹핑 제안 (선택)
10. **`accommodationForm.js` 모듈 전역 상태** — 현재는 문제없으나 인식 차원 기록

## 참고
- 리뷰 톤/구조는 이전 `review-20260409.md`, `review-20260409_해결.md`의 스타일을 따랐습니다.
- CSS는 최소 사용(브라우저 전용 가상 요소만), Tailwind 우선 원칙을 일관되게 적용했습니다.
- 문서만 추가되며 소스 코드 변경은 없습니다.

## Test plan
- [ ] `docs/review-20260414.md` 내용 검토 (이슈 설명, 파일 경로, 중요도)
- [ ] `docs/review-20260414_해결.md`의 수정 전/후 코드가 현재 코드베이스와 일치하는지 확인
- [ ] 수정 가이드의 순서대로 적용 시 상호 충돌이 없는지 확인